### PR TITLE
Cell filter

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -17,8 +17,7 @@ pub struct SATApp {
     callback_wrapper: CadicalCallbackWrapper,
     solver: Solver<CadicalCallbackWrapper>,
     rendered_constraints: Vec<Vec<i32>>,
-    max_length: Option<i32>,
-    max_length_input: String,
+    state: GUIState,
     filter: ListFilter,
 }
 
@@ -36,8 +35,7 @@ impl SATApp {
             callback_wrapper,
             solver,
             rendered_constraints: Vec::new(),
-            max_length: None,
-            max_length_input: String::new(),
+            state: GUIState::new(),
             filter,
         }
     }
@@ -58,8 +56,7 @@ impl Default for SATApp {
             callback_wrapper,
             solver,
             rendered_constraints: Vec::new(),
-            max_length: None,
-            max_length_input: String::new(),
+            state: GUIState::new(),
             filter,
         }
     }
@@ -78,9 +75,25 @@ impl eframe::App for SATApp {
                     constraint_list(self, ui, width);
                 });
                 columns[1].vertical_centered(|ui| {
-                    sudoku_grid(ui, height, width, &self.sudoku);
+                    sudoku_grid(self, ui, height, width);
                 });
             });
         });
+    }
+}
+
+struct GUIState {
+    max_length: Option<i32>,
+    max_length_input: String,
+    selected_cell: Option<(i32, i32)>,
+}
+
+impl GUIState{
+    pub fn new() -> Self {
+        Self {
+            max_length: None,
+            max_length_input: String::new(),
+            selected_cell: None,
+        }
     }
 }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -88,7 +88,7 @@ struct GUIState {
     selected_cell: Option<(i32, i32)>,
 }
 
-impl GUIState{
+impl GUIState {
     pub fn new() -> Self {
         Self {
             max_length: None,

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,12 +1,14 @@
 mod constraint_list;
 mod sudoku_grid;
 
+use std::rc::Rc;
+
 use cadical::Solver;
 use constraint_list::constraint_list;
 use eframe::egui;
 use sudoku_grid::sudoku_grid;
 
-use crate::{cadical_wrapper::CadicalCallbackWrapper, ConstraintList};
+use crate::{cadical_wrapper::CadicalCallbackWrapper, ConstraintList, ListFilter};
 
 /// Main app struct
 pub struct SATApp {
@@ -17,6 +19,7 @@ pub struct SATApp {
     rendered_constraints: Vec<Vec<i32>>,
     max_length: Option<i32>,
     max_length_input: String,
+    filter: ListFilter,
 }
 
 impl SATApp {
@@ -26,6 +29,7 @@ impl SATApp {
             CadicalCallbackWrapper::new(ConstraintList::clone(&constraints.constraints));
         let mut solver = cadical::Solver::with_config("plain").unwrap();
         solver.set_callbacks(Some(callback_wrapper.clone()));
+        let filter = ListFilter::new(Rc::clone(&constraints.constraints));
         Self {
             sudoku,
             constraints,
@@ -34,6 +38,7 @@ impl SATApp {
             rendered_constraints: Vec::new(),
             max_length: None,
             max_length_input: String::new(),
+            filter,
         }
     }
 }
@@ -46,6 +51,7 @@ impl Default for SATApp {
             CadicalCallbackWrapper::new(ConstraintList::clone(&constraints.constraints));
         let mut solver = cadical::Solver::with_config("plain").unwrap();
         solver.set_callbacks(Some(callback_wrapper.clone()));
+        let filter = ListFilter::new(Rc::clone(&constraints.constraints));
         Self {
             sudoku: Vec::new(),
             constraints,
@@ -54,6 +60,7 @@ impl Default for SATApp {
             rendered_constraints: Vec::new(),
             max_length: None,
             max_length_input: String::new(),
+            filter,
         }
     }
 }

--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -5,10 +5,7 @@ use egui::{
 };
 use std::ops::Add;
 
-use crate::{
-    apply_max_length, cnf_converter::identifier_to_tuple, filter_by_max_length, get_sudoku,
-    solve_sudoku,
-};
+use crate::{apply_max_length, cnf_converter::identifier_to_tuple, get_sudoku, solve_sudoku};
 
 use super::SATApp;
 
@@ -30,6 +27,7 @@ pub fn constraint_list(app: &mut SATApp, ui: &mut Ui, width: f32) -> Response {
                 Ok(solved) => {
                     app.sudoku = solved;
                     app.rendered_constraints = app.constraints.constraints.borrow().clone();
+                    app.filter.clear();
                 }
                 Err(err) => {
                     println!("{}", err);
@@ -50,13 +48,12 @@ pub fn constraint_list(app: &mut SATApp, ui: &mut Ui, width: f32) -> Response {
         if ui.button("Filter").clicked() {
             app.max_length = apply_max_length(app.max_length_input.as_str());
             if let Some(max_length) = app.max_length {
-                app.rendered_constraints =
-                    filter_by_max_length(app.constraints.constraints.borrow(), max_length);
+                app.rendered_constraints = app.filter.by_max_length(max_length);
             }
         }
         if ui.button("Clear filters").clicked() {
             app.rendered_constraints = app.constraints.constraints.borrow().clone();
-            app.max_length_input.clear();
+            app.filter.clear();
             app.max_length = None;
         }
     });

--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -27,7 +27,7 @@ pub fn constraint_list(app: &mut SATApp, ui: &mut Ui, width: f32) -> Response {
                 Ok(solved) => {
                     app.sudoku = solved;
                     app.rendered_constraints = app.constraints.constraints.borrow().clone();
-                    app.filter.clear();
+                    app.filter.reinit();
                 }
                 Err(err) => {
                     println!("{}", err);
@@ -53,7 +53,7 @@ pub fn constraint_list(app: &mut SATApp, ui: &mut Ui, width: f32) -> Response {
         }
         if ui.button("Clear filters").clicked() {
             app.rendered_constraints = app.constraints.constraints.borrow().clone();
-            app.filter.clear();
+            app.filter.clear_all();
             app.max_length = None;
         }
     });

--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -38,23 +38,27 @@ pub fn constraint_list(app: &mut SATApp, ui: &mut Ui, width: f32) -> Response {
             "Learned constraints: {}",
             app.constraints.constraints.borrow().len()
         ));
+        ui.label(format!(
+            "Constraints after filtering: {}",
+            app.rendered_constraints.len()
+        ));
     });
 
     // Row for filtering functionality
     ui.horizontal(|ui| {
         let max_length_label = ui.label("Max length: ");
-        ui.text_edit_singleline(&mut app.max_length_input)
+        ui.text_edit_singleline(&mut app.state.max_length_input)
             .labelled_by(max_length_label.id);
         if ui.button("Filter").clicked() {
-            app.max_length = apply_max_length(app.max_length_input.as_str());
-            if let Some(max_length) = app.max_length {
+            app.state.max_length = apply_max_length(app.state.max_length_input.as_str());
+            if let Some(max_length) = app.state.max_length {
                 app.rendered_constraints = app.filter.by_max_length(max_length);
             }
         }
         if ui.button("Clear filters").clicked() {
-            app.rendered_constraints = app.constraints.constraints.borrow().clone();
-            app.filter.clear_all();
-            app.max_length = None;
+            app.rendered_constraints = app.filter.clear_all();
+            app.state.max_length = None;
+            app.state.selected_cell = None;
         }
     });
 

--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -27,6 +27,7 @@ pub fn constraint_list(app: &mut SATApp, ui: &mut Ui, width: f32) -> Response {
                 Ok(solved) => {
                     app.sudoku = solved;
                     app.rendered_constraints = app.constraints.constraints.borrow().clone();
+                    // Reinitialize filrening for a new sudoku
                     app.filter.reinit();
                 }
                 Err(err) => {
@@ -52,11 +53,13 @@ pub fn constraint_list(app: &mut SATApp, ui: &mut Ui, width: f32) -> Response {
         if ui.button("Filter").clicked() {
             app.state.max_length = apply_max_length(app.state.max_length_input.as_str());
             if let Some(max_length) = app.state.max_length {
-                app.rendered_constraints = app.filter.by_max_length(max_length);
+                app.filter.by_max_length(max_length);
+                app.rendered_constraints = app.filter.get_filtered();
             }
         }
         if ui.button("Clear filters").clicked() {
-            app.rendered_constraints = app.filter.clear_all();
+            app.filter.clear_all();
+            app.rendered_constraints = app.filter.get_filtered();
             app.state.max_length = None;
             app.state.selected_cell = None;
         }

--- a/src/gui/sudoku_grid.rs
+++ b/src/gui/sudoku_grid.rs
@@ -4,12 +4,7 @@ use egui::{Color32, Pos2, Rect, Response, Ui, Vec2};
 
 use super::SATApp;
 
-pub fn sudoku_grid(
-    app: &mut SATApp,
-    ui: &mut Ui,
-    height: f32,
-    mut width: f32,
-) -> Response {
+pub fn sudoku_grid(app: &mut SATApp, ui: &mut Ui, height: f32, mut width: f32) -> Response {
     ui.horizontal_wrapped(|ui| {
         let spacing = 2.0;
         width += spacing;

--- a/src/gui/sudoku_grid.rs
+++ b/src/gui/sudoku_grid.rs
@@ -6,8 +6,10 @@ use super::SATApp;
 
 pub fn sudoku_grid(app: &mut SATApp, ui: &mut Ui, height: f32, mut width: f32) -> Response {
     ui.horizontal_wrapped(|ui| {
-        let spacing = 2.0;
-        width += spacing;
+        let block_spacing = 2.0;
+        let square_spacing = 1.0;
+
+        width += block_spacing;
         let mut cell_size = cmp::min(height as i32, width as i32) as f32;
         cell_size /= 9.0;
 
@@ -20,17 +22,23 @@ pub fn sudoku_grid(app: &mut SATApp, ui: &mut Ui, height: f32, mut width: f32) -
         for (i, row) in app.sudoku.iter().enumerate().take(9) {
             // block divider
             if i % 3 == 0 && i != 0 {
-                top_left.y += spacing;
+                top_left.y += block_spacing;
                 bottom_right = top_left + Vec2::new(cell_size, cell_size);
             }
+            // square divider
+            top_left.y += square_spacing;
+            bottom_right.y += square_spacing;
 
             // column
             for (ii, val) in row.iter().enumerate().take(9) {
                 // block divider
                 if ii % 3 == 0 && ii != 0 {
-                    top_left.x += spacing;
+                    top_left.x += block_spacing;
                     bottom_right.x = top_left.x + cell_size;
                 }
+                // square divider
+                top_left.x += square_spacing;
+                bottom_right.x += square_spacing;
 
                 let rect = Rect::from_two_pos(top_left, bottom_right);
                 let rect_action = ui.allocate_rect(rect, egui::Sense::click());

--- a/src/gui/sudoku_grid.rs
+++ b/src/gui/sudoku_grid.rs
@@ -2,11 +2,13 @@ use std::cmp;
 
 use egui::{Color32, Pos2, Rect, Response, Ui, Vec2};
 
+use super::SATApp;
+
 pub fn sudoku_grid(
+    app: &mut SATApp,
     ui: &mut Ui,
     height: f32,
     mut width: f32,
-    sudoku: &[Vec<Option<i32>>],
 ) -> Response {
     ui.horizontal_wrapped(|ui| {
         let spacing = 2.0;
@@ -20,7 +22,7 @@ pub fn sudoku_grid(
         let mut bottom_right = top_left + Vec2::new(cell_size, cell_size);
 
         // row
-        for (i, row) in sudoku.iter().enumerate().take(9) {
+        for (i, row) in app.sudoku.iter().enumerate().take(9) {
             // block divider
             if i % 3 == 0 && i != 0 {
                 top_left.y += spacing;
@@ -38,12 +40,22 @@ pub fn sudoku_grid(
                 let rect = Rect::from_two_pos(top_left, bottom_right);
                 let rect_action = ui.allocate_rect(rect, egui::Sense::click());
 
-                // could be used to show info about particular cell
+                // Filter constraint list by cell
                 if rect_action.clicked() {
-                    println!("Rect at row:{i} column:{ii} clicked");
+                    if app.state.selected_cell == Some((i as i32 + 1, ii as i32 + 1)) {
+                        app.state.selected_cell = None;
+                        app.rendered_constraints = app.filter.clear_cell();
+                    } else {
+                        app.state.selected_cell = Some((i as i32 + 1, ii as i32 + 1));
+                        app.rendered_constraints = app.filter.by_cell(i as i32 + 1, ii as i32 + 1);
+                    }
                 }
 
-                ui.painter().rect_filled(rect, 0.0, Color32::GRAY);
+                if app.state.selected_cell == Some((i as i32 + 1, ii as i32 + 1)) {
+                    ui.painter().rect_filled(rect, 0.0, Color32::LIGHT_BLUE);
+                } else {
+                    ui.painter().rect_filled(rect, 0.0, Color32::GRAY);
+                }
 
                 if let Some(num) = val {
                     let center = top_left + Vec2::new(cell_size / 2.0, cell_size / 2.0);

--- a/src/gui/sudoku_grid.rs
+++ b/src/gui/sudoku_grid.rs
@@ -47,11 +47,12 @@ pub fn sudoku_grid(app: &mut SATApp, ui: &mut Ui, height: f32, mut width: f32) -
                 if rect_action.clicked() {
                     if app.state.selected_cell == Some((i as i32 + 1, ii as i32 + 1)) {
                         app.state.selected_cell = None;
-                        app.rendered_constraints = app.filter.clear_cell();
+                        app.filter.clear_cell();
                     } else {
                         app.state.selected_cell = Some((i as i32 + 1, ii as i32 + 1));
-                        app.rendered_constraints = app.filter.by_cell(i as i32 + 1, ii as i32 + 1);
+                        app.filter.by_cell(i as i32 + 1, ii as i32 + 1);
                     }
+                    app.rendered_constraints = app.filter.get_filtered();
                 }
 
                 if app.state.selected_cell == Some((i as i32 + 1, ii as i32 + 1)) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,6 @@ impl ListFilter {
         self.length_filter = (0..self.constraints.borrow().len()).collect();
         self.apply_filters()
     }
-
 }
 
 pub fn solve_sudoku(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,17 +105,21 @@ impl ListFilter {
         self.apply_filters()
     }
 
-    pub fn clear_length(&mut self) {
+    pub fn clear_length(&mut self) -> Vec<Vec<i32>> {
         self.length_filter = (0..self.constraints.borrow().len()).collect();
+        self.apply_filters()
     }
 
-    pub fn clear_cell(&mut self) {
+    pub fn clear_cell(&mut self) -> Vec<Vec<i32>> {
         self.cell_filter = (0..self.constraints.borrow().len()).collect();
+        self.apply_filters()
     }
 
-    pub fn clear_all(&mut self) {
+    pub fn clear_all(&mut self) -> Vec<Vec<i32>> {
+        // This will apply the filters several times, but avoids code repetition
+        // Change if this becomes a problem!
         self.clear_length();
-        self.clear_cell();
+        self.clear_cell()
     }
 
     pub fn by_cell(&mut self, row: i32, col: i32,) -> Vec<Vec<i32>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,28 @@ impl Default for ConstraintList {
     }
 }
 
+struct ListFilter {
+    constraints: Rc<RefCell<Vec<Vec<i32>>>>,
+    pub length_filter: HashSet<usize>,
+    pub cell_filter: HashSet<usize>,
+}
+
+impl ListFilter {
+    pub fn rebuild_filtered_list(&self) -> Vec<Vec<i32>> {
+        let mut final_set = self.length_filter.clone();
+
+        // Add additional filters with && in the same closure
+        final_set.retain( |index| self.cell_filter.contains(index));
+
+        let mut final_list = Vec::new();
+        for index in final_set {
+            final_list.push(self.constraints.borrow()[index].clone());
+        }
+
+        final_list
+    }
+}
+
 pub fn solve_sudoku(
     sudoku_clues: &[Vec<Option<i32>>],
     solver: &mut Solver<CadicalCallbackWrapper>,
@@ -97,11 +119,11 @@ pub fn filter_by_max_length(constraints: Ref<Vec<Vec<i32>>>, max_length: i32) ->
         .collect()
 }
 
-pub fn filter_by_cell(filtered_constraints: Vec<Vec<i32>>, x: i32, y: i32) -> HashMap<(i32, i32), HashSet<i32>> {
-    for n in 1..filtered_contraints.len() {
-        
-    }
-}
+//pub fn filter_by_cell(filtered_constraints: Vec<Vec<i32>>, x: i32, y: i32) -> HashMap<(i32, i32), HashSet<i32>> {
+//    for n in 1..filtered_contraints.len() {
+//        
+//    }
+//}
 mod tests {
     #[test]
     fn test_get_sudoku() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod cnf_converter;
 pub mod gui;
 
 use std::{cell::Ref, cell::RefCell, fs, num::ParseIntError, rc::Rc};
+use std::collections::{HashMap, HashSet};
 
 use cadical::Solver;
 
@@ -96,6 +97,9 @@ pub fn filter_by_max_length(constraints: Ref<Vec<Vec<i32>>>, max_length: i32) ->
         .collect()
 }
 
+pub fn filter_by_cell(filtered_constraints: Vec<Vec<i32>>, x: i32, y: i32) -> HashMap<(i32, i32), HashSet<i32>> {
+
+}
 mod tests {
     #[test]
     fn test_get_sudoku() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,9 @@ pub fn filter_by_max_length(constraints: Ref<Vec<Vec<i32>>>, max_length: i32) ->
 }
 
 pub fn filter_by_cell(filtered_constraints: Vec<Vec<i32>>, x: i32, y: i32) -> HashMap<(i32, i32), HashSet<i32>> {
-
+    for n in 1..filtered_contraints.len() {
+        
+    }
 }
 mod tests {
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ impl ListFilter {
         }
     }
 
-    fn apply_filters(&self) -> Vec<Vec<i32>> {
+    fn get_filtered(&self) -> Vec<Vec<i32>> {
         let mut final_set = self.length_filter.clone();
 
         // Add additional filters with && in the same closure
@@ -94,7 +94,7 @@ impl ListFilter {
     }
 
     /// Filters the constraints by the given max_length.
-    pub fn by_max_length(&mut self, max_length: i32) -> Vec<Vec<i32>> {
+    pub fn by_max_length(&mut self, max_length: i32) {
         let mut filter_set = HashSet::new();
         for (index, constraint) in self.constraints.borrow().iter().enumerate() {
             if constraint.len() as i32 <= max_length {
@@ -102,32 +102,25 @@ impl ListFilter {
             }
         }
         self.length_filter = filter_set;
-        // Return new filtered list
-        self.apply_filters()
     }
 
-    pub fn clear_cell(&mut self) -> Vec<Vec<i32>> {
-        self.cell_filter = (0..self.constraints.borrow().len()).collect();
-        self.apply_filters()
-    }
-
-    pub fn clear_all(&mut self) -> Vec<Vec<i32>> {
-        // This will apply the filters several times, but avoids code repetition
-        // Change if this becomes a problem!
-        self.clear_length();
-        self.clear_cell()
-    }
-
-    pub fn by_cell(&mut self, row: i32, col: i32) -> Vec<Vec<i32>> {
+    pub fn by_cell(&mut self, row: i32, col: i32) {
         if let Some(cell_set) = self.cell_constraints.get(&(row, col)) {
             self.cell_filter = cell_set.clone()
         }
-        self.apply_filters()
     }
 
-    pub fn clear_length(&mut self) -> Vec<Vec<i32>> {
+    pub fn clear_length(&mut self) {
         self.length_filter = (0..self.constraints.borrow().len()).collect();
-        self.apply_filters()
+    }
+
+    pub fn clear_cell(&mut self) {
+        self.cell_filter = (0..self.constraints.borrow().len()).collect();
+    }
+
+    pub fn clear_all(&mut self) {
+        self.clear_length();
+        self.clear_cell();
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,18 @@ impl ListFilter {
         self.apply_filters()
     }
 
+    pub fn clear_cell(&mut self) -> Vec<Vec<i32>> {
+        self.cell_filter = (0..self.constraints.borrow().len()).collect();
+        self.apply_filters()
+    }
+
+    pub fn clear_all(&mut self) -> Vec<Vec<i32>> {
+        // This will apply the filters several times, but avoids code repetition
+        // Change if this becomes a problem!
+        self.clear_length();
+        self.clear_cell()
+    }
+
     pub fn by_cell(&mut self, row: i32, col: i32) -> Vec<Vec<i32>> {
         if let Some(cell_set) = self.cell_constraints.get(&(row, col)) {
             self.cell_filter = cell_set.clone()
@@ -118,17 +130,6 @@ impl ListFilter {
         self.apply_filters()
     }
 
-    pub fn clear_cell(&mut self) -> Vec<Vec<i32>> {
-        self.cell_filter = (0..self.constraints.borrow().len()).collect();
-        self.apply_filters()
-    }
-
-    pub fn clear_all(&mut self) -> Vec<Vec<i32>> {
-        // This will apply the filters several times, but avoids code repetition
-        // Change if this becomes a problem!
-        self.clear_length();
-        self.clear_cell()
-    }
 }
 
 pub fn solve_sudoku(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,248 @@
+#[test]
+fn test_get_sudoku() {
+    use super::*;
+
+    let sudoku = get_sudoku("data/sample_sudoku.txt".to_string());
+    let should_be = vec![
+        vec![None, None, None, None, None, None, None, Some(1), None],
+        vec![Some(4), None, None, None, None, None, None, None, None],
+        vec![None, Some(2), None, None, None, None, None, None, None],
+        vec![
+            None,
+            None,
+            None,
+            None,
+            Some(5),
+            None,
+            Some(4),
+            None,
+            Some(7),
+        ],
+        vec![None, None, Some(8), None, None, None, Some(3), None, None],
+        vec![None, None, Some(1), None, Some(9), None, None, None, None],
+        vec![
+            Some(3),
+            None,
+            None,
+            Some(4),
+            None,
+            None,
+            Some(2),
+            None,
+            None,
+        ],
+        vec![None, Some(5), None, Some(1), None, None, None, None, None],
+        vec![None, None, None, Some(8), None, Some(6), None, None, None],
+    ];
+    assert_eq!(sudoku, should_be);
+}
+
+#[test]
+fn test_solve_sudoku() {
+    use super::*;
+
+    let sudoku = get_sudoku("data/sample_sudoku.txt".to_string());
+    let mut solver = cadical::Solver::with_config("plain").unwrap();
+    let callback_wrapper = CadicalCallbackWrapper::new(ConstraintList::new());
+    solver.set_callbacks(Some(callback_wrapper.clone()));
+
+    let solved = solve_sudoku(&sudoku, &mut solver).unwrap();
+    let should_be = vec![
+        vec![
+            Some(6),
+            Some(9),
+            Some(3),
+            Some(7),
+            Some(8),
+            Some(4),
+            Some(5),
+            Some(1),
+            Some(2),
+        ],
+        vec![
+            Some(4),
+            Some(8),
+            Some(7),
+            Some(5),
+            Some(1),
+            Some(2),
+            Some(9),
+            Some(3),
+            Some(6),
+        ],
+        vec![
+            Some(1),
+            Some(2),
+            Some(5),
+            Some(9),
+            Some(6),
+            Some(3),
+            Some(8),
+            Some(7),
+            Some(4),
+        ],
+        vec![
+            Some(9),
+            Some(3),
+            Some(2),
+            Some(6),
+            Some(5),
+            Some(1),
+            Some(4),
+            Some(8),
+            Some(7),
+        ],
+        vec![
+            Some(5),
+            Some(6),
+            Some(8),
+            Some(2),
+            Some(4),
+            Some(7),
+            Some(3),
+            Some(9),
+            Some(1),
+        ],
+        vec![
+            Some(7),
+            Some(4),
+            Some(1),
+            Some(3),
+            Some(9),
+            Some(8),
+            Some(6),
+            Some(2),
+            Some(5),
+        ],
+        vec![
+            Some(3),
+            Some(1),
+            Some(9),
+            Some(4),
+            Some(7),
+            Some(5),
+            Some(2),
+            Some(6),
+            Some(8),
+        ],
+        vec![
+            Some(8),
+            Some(5),
+            Some(6),
+            Some(1),
+            Some(2),
+            Some(9),
+            Some(7),
+            Some(4),
+            Some(3),
+        ],
+        vec![
+            Some(2),
+            Some(7),
+            Some(4),
+            Some(8),
+            Some(3),
+            Some(6),
+            Some(1),
+            Some(5),
+            Some(9),
+        ],
+    ];
+    assert_eq!(solved, should_be);
+}
+
+#[test]
+fn test_apply_max_length_valid_input() {
+    use super::*;
+
+    let max_length = String::from("10");
+
+    let applied = apply_max_length(&max_length);
+    assert_eq!(applied, Some(10));
+}
+
+#[test]
+fn test_apply_max_length_negative() {
+    use super::*;
+
+    let max_length = String::from("-10");
+
+    let applied = apply_max_length(&max_length);
+    assert_eq!(applied, None);
+}
+
+#[test]
+fn test_apply_max_length_not_numeric() {
+    use super::*;
+
+    let max_length = String::from("test");
+
+    let applied = apply_max_length(&max_length);
+    assert_eq!(applied, None);
+}
+
+#[test]
+fn test_apply_max_length_empty() {
+    use super::*;
+
+    let max_length = String::new();
+
+    let applied = apply_max_length(&max_length);
+    assert_eq!(applied, None);
+}
+
+#[test]
+fn test_filter_by_max_length() {
+    use super::*;
+    let constraints = Rc::new(RefCell::new(vec![vec![0; 10], vec![0; 3], vec![0; 5]]));
+    let mut filter: ListFilter = ListFilter::new(constraints);
+
+    let filtered = filter.by_max_length(4);
+    assert_eq!(filtered.len(), 1);
+
+    let filtered2 = filter.by_max_length(5);
+    assert_eq!(filtered2.len(), 2);
+
+    let filtered3 = filter.by_max_length(1);
+    assert_eq!(filtered3.len(), 0)
+}
+
+#[test]
+fn test_filter_by_cell() {
+    use super::*;
+    let constraints = Rc::new(RefCell::new(vec![vec![1; 10], vec![10; 3], vec![10; 3]]));
+    let mut filter: ListFilter = ListFilter::new(constraints);
+    filter.reinit();
+
+    let filtered = filter.by_cell(1, 1);
+    assert_eq!(filtered.len(), 1);
+
+    let filtered2 = filter.by_cell(1, 2);
+    assert_eq!(filtered2.len(), 2);
+
+    let filtered3 = filter.by_cell(2, 2);
+    assert_eq!(filtered3.len(), 0);
+}
+
+#[test]
+fn test_clear_filters_and_multiple_filters() {
+    use super::*;
+    let constraints = Rc::new(RefCell::new(vec![vec![1; 10], vec![1; 3], vec![10; 3]]));
+    let mut filter: ListFilter = ListFilter::new(constraints);
+    filter.reinit();
+
+    let filtered = filter.by_cell(1, 1);
+    assert_eq!(filtered.len(), 2);
+    let filtered2 = filter.by_max_length(3);
+    assert_eq!(filtered2.len(), 1);
+    let cleared = filter.clear_cell();
+    assert_eq!(cleared.len(), 2);
+    let cleared2 = filter.clear_length();
+    assert_eq!(cleared2.len(), 3);
+
+    let _ = filter.by_cell(1, 1);
+    let filtered4 = filter.by_max_length(3);
+    assert_eq!(filtered4.len(), 1);
+    let cleared3 = filter.clear_all();
+    assert_eq!(cleared3.len(), 3);
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -197,13 +197,16 @@ fn test_filter_by_max_length() {
     let constraints = Rc::new(RefCell::new(vec![vec![0; 10], vec![0; 3], vec![0; 5]]));
     let mut filter: ListFilter = ListFilter::new(constraints);
 
-    let filtered = filter.by_max_length(4);
+    filter.by_max_length(4);
+    let filtered = filter.get_filtered();
     assert_eq!(filtered.len(), 1);
 
-    let filtered2 = filter.by_max_length(5);
+    filter.by_max_length(5);
+    let filtered2 = filter.get_filtered();
     assert_eq!(filtered2.len(), 2);
 
-    let filtered3 = filter.by_max_length(1);
+    filter.by_max_length(1);
+    let filtered3 = filter.get_filtered();
     assert_eq!(filtered3.len(), 0)
 }
 
@@ -214,13 +217,16 @@ fn test_filter_by_cell() {
     let mut filter: ListFilter = ListFilter::new(constraints);
     filter.reinit();
 
-    let filtered = filter.by_cell(1, 1);
+    filter.by_cell(1, 1);
+    let filtered = filter.get_filtered();
     assert_eq!(filtered.len(), 1);
 
-    let filtered2 = filter.by_cell(1, 2);
+    filter.by_cell(1, 2);
+    let filtered2 = filter.get_filtered();
     assert_eq!(filtered2.len(), 2);
 
-    let filtered3 = filter.by_cell(2, 2);
+    filter.by_cell(2, 2);
+    let filtered3 = filter.get_filtered();
     assert_eq!(filtered3.len(), 0);
 }
 
@@ -231,18 +237,24 @@ fn test_clear_filters_and_multiple_filters() {
     let mut filter: ListFilter = ListFilter::new(constraints);
     filter.reinit();
 
-    let filtered = filter.by_cell(1, 1);
+    filter.by_cell(1, 1);
+    let filtered = filter.get_filtered();
     assert_eq!(filtered.len(), 2);
-    let filtered2 = filter.by_max_length(3);
+    filter.by_max_length(3);
+    let filtered2 = filter.get_filtered();
     assert_eq!(filtered2.len(), 1);
-    let cleared = filter.clear_cell();
+    filter.clear_cell();
+    let cleared = filter.get_filtered();
     assert_eq!(cleared.len(), 2);
-    let cleared2 = filter.clear_length();
+    filter.clear_length();
+    let cleared2 = filter.get_filtered();
     assert_eq!(cleared2.len(), 3);
 
     let _ = filter.by_cell(1, 1);
-    let filtered4 = filter.by_max_length(3);
+    filter.by_max_length(3);
+    let filtered4 = filter.get_filtered();
     assert_eq!(filtered4.len(), 1);
-    let cleared3 = filter.clear_all();
+    filter.clear_all();
+    let cleared3 = filter.get_filtered();
     assert_eq!(cleared3.len(), 3);
 }


### PR DESCRIPTION
Add ability to filter for constraints that apply to a specific cell of the sudoku grid. Changes:
- Clicking on a cell selects that cell, and only shows constraints that apply to it
- Clicking the selected cell again de-selects it
- The user can see how many constraints are left after all the filters are applied

We also created a much more robust and modular system for adding new filters in future. Tests from lib.rs were moved into a separate tests.rs file.