### PR TITLE
Center and contain sudoku grid

### DIFF
--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -45,7 +45,8 @@ pub fn constraint_list(app: &mut SATApp, ui: &mut Ui, width: f32) -> Response {
     // Row for filtering functionality
     ui.horizontal_wrapped(|ui| {
         let max_length_label = ui.label("Max length: ");
-        ui.text_edit_singleline(&mut app.max_length_input)
+        //ui.text_edit_singleline(&mut app.max_length_input)
+        ui.add(egui::TextEdit::singleline(&mut app.max_length_input).desired_width(50.0))
             .labelled_by(max_length_label.id);
         if ui.button("Filter").clicked() {
             app.max_length = apply_max_length(app.max_length_input.as_str());

--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -15,7 +15,7 @@ use super::SATApp;
 /// Constraint list GUI element
 pub fn constraint_list(app: &mut SATApp, ui: &mut Ui, width: f32) -> Response {
     // Row for basic functionality buttons
-    ui.horizontal(|ui| {
+    ui.horizontal_wrapped(|ui| {
         if ui.button("Open file...").clicked() {
             if let Some(file_path) = rfd::FileDialog::new().pick_file() {
                 app.sudoku = get_sudoku(file_path.display().to_string());
@@ -43,7 +43,7 @@ pub fn constraint_list(app: &mut SATApp, ui: &mut Ui, width: f32) -> Response {
     });
 
     // Row for filtering functionality
-    ui.horizontal(|ui| {
+    ui.horizontal_wrapped(|ui| {
         let max_length_label = ui.label("Max length: ");
         ui.text_edit_singleline(&mut app.max_length_input)
             .labelled_by(max_length_label.id);

--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -1,7 +1,7 @@
 use cadical::Solver;
 use egui::{
     text::{LayoutJob, TextFormat},
-    Color32, FontId, NumExt, Rect, Response, ScrollArea, TextStyle, Ui, Vec2, Label,
+    Color32, FontId, Label, NumExt, Rect, Response, ScrollArea, TextStyle, Ui, Vec2,
 };
 use std::ops::Add;
 
@@ -35,14 +35,20 @@ pub fn constraint_list(app: &mut SATApp, ui: &mut Ui, width: f32) -> Response {
                 }
             }
         }
-        ui.add(Label::new(format!(
-            "Learned constraints: {}",
-            app.constraints.constraints.borrow().len()
-        )).wrap(false));
-        ui.add(Label::new(format!(
-            "Constraints after filtering: {}",
-            app.rendered_constraints.len()
-        )).wrap(false));
+        ui.add(
+            Label::new(format!(
+                "Learned constraints: {}",
+                app.constraints.constraints.borrow().len()
+            ))
+            .wrap(false),
+        );
+        ui.add(
+            Label::new(format!(
+                "Constraints after filtering: {}",
+                app.rendered_constraints.len()
+            ))
+            .wrap(false),
+        );
     });
 
     // Row for filtering functionality

--- a/src/gui/sudoku_grid.rs
+++ b/src/gui/sudoku_grid.rs
@@ -2,7 +2,6 @@ use std::cmp;
 
 use egui::{Color32, Pos2, Rect, Response, Ui, Vec2};
 
-
 use super::SATApp;
 
 pub fn sudoku_grid(app: &mut SATApp, ui: &mut Ui, mut height: f32, mut width: f32) -> Response {

--- a/src/gui/sudoku_grid.rs
+++ b/src/gui/sudoku_grid.rs
@@ -19,8 +19,8 @@ pub fn sudoku_grid(
         let block_size = cell_size * 3.0;
 
         // using these centers the sudoku in the middle of its column
-        height = (height - block_size*3.0) / 2.0;
-        width = width + (width - block_size*3.0) / 2.0; 
+        height = (height - block_size * 3.0) / 2.0;
+        width = width + (width - block_size * 3.0) / 2.0;
 
         let mut top_left = Pos2::new(width, height);
         let mut bottom_right = top_left + Vec2::new(cell_size, cell_size);

--- a/src/gui/sudoku_grid.rs
+++ b/src/gui/sudoku_grid.rs
@@ -4,7 +4,7 @@ use egui::{Color32, Pos2, Rect, Response, Ui, Vec2};
 
 pub fn sudoku_grid(
     ui: &mut Ui,
-    height: f32,
+    mut height: f32,
     mut width: f32,
     sudoku: &[Vec<Option<i32>>],
 ) -> Response {
@@ -18,7 +18,11 @@ pub fn sudoku_grid(
 
         let block_size = cell_size * 3.0;
 
-        let mut top_left = Pos2::new(width, 0.0);
+        // using these centers the sudoku in the middle of its column
+        height = (height - block_size*3.0) / 2.0;
+        width = width + (width - block_size*3.0) / 2.0; 
+
+        let mut top_left = Pos2::new(width, height);
         let mut bottom_right = top_left + Vec2::new(cell_size, cell_size);
 
         // row

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,13 @@ use egui::Vec2;
 use sat_step::gui::SATApp;
 
 fn main() -> Result<(), eframe::Error> {
-    let mut options = eframe::NativeOptions::default();
-    options.min_window_size = Some(Vec2 { x: (480.0), y: (240.0) });
-
+    let options = eframe::NativeOptions {
+        min_window_size: Some(Vec2 {
+            x: (480.0),
+            y: (240.0),
+        }),
+        ..Default::default()
+    };
     let app = Box::new(SATApp::new(vec![vec![None; 9]; 9]));
 
     eframe::run_native("SAT STEP", options, Box::new(|_cc| app))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,10 @@
+use egui::Vec2;
 use sat_step::gui::SATApp;
 
 fn main() -> Result<(), eframe::Error> {
-    let options = eframe::NativeOptions::default();
+    let mut options = eframe::NativeOptions::default();
+    options.min_window_size = Some(Vec2 { x: (480.0), y: (240.0) });
+
     let app = Box::new(SATApp::new(vec![vec![None; 9]; 9]));
 
     eframe::run_native("SAT STEP", options, Box::new(|_cc| app))


### PR DESCRIPTION
I set a minimum size for the app window, centered the sudoku grid in its column, and made the buttons etc. in the left column wrap around to keep them from being hidden behind the sudoku on small window sizes. As a result, the smallest window looks like this:

![image](https://github.com/SAT-STEP/SAT-STEP/assets/94612974/bad3cc4a-265e-4070-bbd3-c1d2c37c73a2)

And when there's space around the sudoku on either the y or x axis, the sudoku sits in the middle:

![image](https://github.com/SAT-STEP/SAT-STEP/assets/94612974/0a85e019-6495-485e-8cc1-cc389377c1b1)

I achieved this by calculating the point for the upper left corner of the sudoku based on the parent column's height and width.

I also modified the filtering input field to be much smaller, but long enough to show three digits. 

If something should be still modified I can do it.