### PR TITLE
Fixed crashes

### DIFF
--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -35,6 +35,7 @@ impl SATApp {
                             self.sudoku = sudoku_vec;
                             self.constraints.clear();
                             self.rendered_constraints = Vec::new();
+                            self.filter.reinit();
                             self.solver = Solver::with_config("plain").unwrap();
                             self.solver
                                 .set_callbacks(Some(self.callback_wrapper.clone()));


### PR DESCRIPTION
Made SATApp clear its field `filter` when a new sudoku file is opened in `gui/constraint_list.rs`. This fixed crashing.