### PR TITLE
Gui improvements

### DIFF
--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -154,7 +154,8 @@ impl SATApp {
             let font = FontId::new(text_scale, font_id.family.clone());
 
             let row_number_label =
-                ui.label(RichText::new("Number of rows per page: ").size(text_scale));
+                ui.label(RichText::new("Number of rows per page: ").size(text_scale))
+                .on_hover_text(RichText::new("Empty and * put all rows on a single page.").italics());
             ui.add(
                 egui::TextEdit::singleline(&mut self.state.page_length_input)
                     .desired_width(5.0 * text_scale)

--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -17,7 +17,8 @@ impl SATApp {
 
         egui::Grid::new("grid")
         .num_columns(1)
-        .spacing([0.0, 10.0])
+        .striped(true)
+        .spacing([0.0, text_scale*0.5])
         .show(ui, |ui| {
             self.buttons(ui, text_scale);
             ui.end_row();
@@ -98,6 +99,7 @@ impl SATApp {
                 )
                 .wrap(false),
             );
+            ui.separator();
             ui.add(
                 Label::new(
                     RichText::new(format!(

--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -16,28 +16,26 @@ impl SATApp {
         let text_scale = (width / 35.0).max(10.0);
 
         egui::Grid::new("grid")
-        .num_columns(1)
-        .striped(true)
-        .spacing([0.0, text_scale*0.5])
-        .show(ui, |ui| {
-            self.buttons(ui, text_scale);
-            ui.end_row();
+            .num_columns(1)
+            .striped(true)
+            .spacing([0.0, text_scale * 0.5])
+            .show(ui, |ui| {
+                self.buttons(ui, text_scale);
+                ui.end_row();
 
-            self.learned_constraints_labels(ui, text_scale);
-            ui.end_row();
+                self.learned_constraints_labels(ui, text_scale);
+                ui.end_row();
 
-            self.filters(ui, text_scale);
-            ui.end_row();
+                self.filters(ui, text_scale);
+                ui.end_row();
 
-            self.page_length_input(ui, text_scale);
-            ui.end_row();
+                self.page_length_input(ui, text_scale);
+                ui.end_row();
 
-            self.page_buttons(ui, text_scale);
-            ui.end_row();
-
-        });
+                self.page_buttons(ui, text_scale);
+                ui.end_row();
+            });
         self.list_of_constraints(ui, text_scale).response
-       
     }
 
     fn buttons(&mut self, ui: &mut Ui, text_scale: f32) -> egui::InnerResponse<()> {
@@ -86,11 +84,14 @@ impl SATApp {
                     }
                 }
             }
-            
         })
     }
 
-    fn learned_constraints_labels(&mut self, ui: &mut Ui, text_scale: f32) -> egui::InnerResponse<()> {
+    fn learned_constraints_labels(
+        &mut self,
+        ui: &mut Ui,
+        text_scale: f32,
+    ) -> egui::InnerResponse<()> {
         ui.horizontal_wrapped(|ui| {
             ui.add(
                 Label::new(
@@ -116,7 +117,8 @@ impl SATApp {
     fn filters(&mut self, ui: &mut Ui, text_scale: f32) -> egui::InnerResponse<()> {
         // Row for filtering functionality
         ui.horizontal(|ui| {
-            let max_length_label = ui.label(RichText::new("Max. constraint length: ").size(text_scale));
+            let max_length_label =
+                ui.label(RichText::new("Max. constraint length: ").size(text_scale));
 
             let font_id = TextStyle::Body.resolve(ui.style());
             let font = FontId::new(text_scale, font_id.family.clone());
@@ -137,10 +139,7 @@ impl SATApp {
                 self.rendered_constraints =
                     create_tuples_from_constraints(self.state.get_filtered());
             }
-            if ui
-                .button(RichText::new("Clear").size(text_scale))
-                .clicked()
-            {
+            if ui.button(RichText::new("Clear").size(text_scale)).clicked() {
                 self.state.clear_filters();
                 self.rendered_constraints =
                     create_tuples_from_constraints(self.state.get_filtered());
@@ -153,9 +152,11 @@ impl SATApp {
             let font_id = TextStyle::Body.resolve(ui.style());
             let font = FontId::new(text_scale, font_id.family.clone());
 
-            let row_number_label =
-                ui.label(RichText::new("Number of rows per page: ").size(text_scale))
-                .on_hover_text(RichText::new("Empty and * put all rows on a single page.").italics());
+            let row_number_label = ui
+                .label(RichText::new("Number of rows per page: ").size(text_scale))
+                .on_hover_text(
+                    RichText::new("Empty and * put all rows on a single page.").italics(),
+                );
             ui.add(
                 egui::TextEdit::singleline(&mut self.state.page_length_input)
                     .desired_width(5.0 * text_scale)

--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -14,15 +14,33 @@ impl SATApp {
     pub fn constraint_list(&mut self, ui: &mut Ui, width: f32) -> Response {
         // Text scale magic numbers chosen based on testing through ui
         let text_scale = (width / 35.0).max(10.0);
-        self.buttons(ui, text_scale);
-        self.filters(ui, text_scale);
-        self.page_length_input(ui, text_scale);
-        self.page_buttons(ui, text_scale);
+
+        egui::Grid::new("grid")
+        .num_columns(1)
+        .spacing([0.0, 10.0])
+        .show(ui, |ui| {
+            self.buttons(ui, text_scale);
+            ui.end_row();
+
+            self.learned_constraints_labels(ui, text_scale);
+            ui.end_row();
+
+            self.filters(ui, text_scale);
+            ui.end_row();
+
+            self.page_length_input(ui, text_scale);
+            ui.end_row();
+
+            self.page_buttons(ui, text_scale);
+            ui.end_row();
+
+        });
         self.list_of_constraints(ui, text_scale).response
+       
     }
 
     fn buttons(&mut self, ui: &mut Ui, text_scale: f32) -> egui::InnerResponse<()> {
-        ui.horizontal_wrapped(|ui| {
+        ui.horizontal(|ui| {
             if ui
                 .button(RichText::new("Open file...").size(text_scale))
                 .clicked()
@@ -67,6 +85,12 @@ impl SATApp {
                     }
                 }
             }
+            
+        })
+    }
+
+    fn learned_constraints_labels(&mut self, ui: &mut Ui, text_scale: f32) -> egui::InnerResponse<()> {
+        ui.horizontal_wrapped(|ui| {
             ui.add(
                 Label::new(
                     RichText::new(format!("Learned constraints: {}", self.constraints.len()))
@@ -86,12 +110,11 @@ impl SATApp {
             );
         })
     }
-
     // Row for filtering functionality
     fn filters(&mut self, ui: &mut Ui, text_scale: f32) -> egui::InnerResponse<()> {
         // Row for filtering functionality
-        ui.horizontal_wrapped(|ui| {
-            let max_length_label = ui.label(RichText::new("Max length: ").size(text_scale));
+        ui.horizontal(|ui| {
+            let max_length_label = ui.label(RichText::new("Max. constraint length: ").size(text_scale));
 
             let font_id = TextStyle::Body.resolve(ui.style());
             let font = FontId::new(text_scale, font_id.family.clone());
@@ -105,7 +128,7 @@ impl SATApp {
             .labelled_by(max_length_label.id);
 
             if ui
-                .button(RichText::new("Filter").size(text_scale))
+                .button(RichText::new("Select").size(text_scale))
                 .clicked()
             {
                 self.state.filter_by_max_length();
@@ -113,7 +136,7 @@ impl SATApp {
                     create_tuples_from_constraints(self.state.get_filtered());
             }
             if ui
-                .button(RichText::new("Clear filters").size(text_scale))
+                .button(RichText::new("Clear").size(text_scale))
                 .clicked()
             {
                 self.state.clear_filters();
@@ -124,7 +147,7 @@ impl SATApp {
     }
 
     fn page_length_input(&mut self, ui: &mut Ui, text_scale: f32) -> egui::InnerResponse<()> {
-        ui.horizontal_wrapped(|ui| {
+        ui.horizontal(|ui| {
             let font_id = TextStyle::Body.resolve(ui.style());
             let font = FontId::new(text_scale, font_id.family.clone());
 

--- a/src/gui/sudoku_grid.rs
+++ b/src/gui/sudoku_grid.rs
@@ -208,17 +208,20 @@ fn draw_little_numbers(
 
         // if value of the picked cell is negative, it will be shown in red,
         // if not negative, in blue
-        let c_value = constraints[c_index].2;
+        let mut c_value = constraints[c_index].2.to_string();
         let mut c_value_color = Color32::BLUE;
-        if c_value < 0 {
+        if constraints[c_index].2 < 0 {
             c_value_color = Color32::RED;
+        } else {
+            // Adding a whitespace makes the positive values also be 2 chars long
+            c_value = format!(" {}", c_value);
         }
 
         ui.painter().text(
             little_top_left,
             egui::Align2::LEFT_TOP,
-            constraints[c_index].2.to_string(),
-            egui::FontId::new(cell_size * 0.3, egui::FontFamily::Monospace),
+            c_value,
+            egui::FontId::new(cell_size * 0.28, egui::FontFamily::Monospace),
             c_value_color,
         );
         little_top_left.x += cell_size / 3.0;


### PR DESCRIPTION
Any feedback and ideas on the GUI very welcome.

I changed the upper left corner of the UI to look like a grid and not wrap, like this:
![image](https://github.com/SAT-STEP/SAT-STEP/assets/94612974/d6f628f1-d33f-4493-8986-a49a42072624)

Compared to the old:
![image](https://github.com/SAT-STEP/SAT-STEP/assets/94612974/5bb0aa4f-0e74-4cbb-901c-a6af4d092c07)

I also changed to button labels to be more "intuitive" in my opinion. If you have any suggestions on how to improve further, even if it would look vastly different, please comment.

Another change made was to adjust the little numbers inside the sudoku cells. This is the changed:
![image](https://github.com/SAT-STEP/SAT-STEP/assets/94612974/38550bc9-7371-4098-bd63-d0065939e429)

While this is what's in `main` and `development`:
![image](https://github.com/SAT-STEP/SAT-STEP/assets/94612974/5a921622-cf41-4547-9f7c-032df2f73571)


### Other changes:
Added hoverable text to guide the user:
![image](https://github.com/SAT-STEP/SAT-STEP/assets/94612974/2354ce32-f04d-4047-a4bf-a90908b39c7c)


