### PR TITLE
Binary cnf

### DIFF
--- a/src/binary_cnf.rs
+++ b/src/binary_cnf.rs
@@ -168,7 +168,7 @@ pub fn identifier_to_tuple(mut identifier: i32) -> (i32, i32, i32, bool) {
     // Reverse CNF-identifier creation
     // Return tuple of (row, col, bit_index, bit_value) from identifier
     // bit_value will be false for negative ids, positive otherwise
-    let bit_value = if identifier > 0 { true } else { false };
+    let bit_value = identifier > 0;
     identifier = identifier.abs() - 1;
     (
         identifier / (9 * 4) + 1,
@@ -183,7 +183,7 @@ pub fn eq_identifier_to_tuple(mut identifier: i32) -> (i32, i32, i32, i32, i32, 
     // Reverse CNF-identifier creation for equality constraints
     // Return tuple of (row, col, row2, col2, bit_index, equal) from identifier
     // equal will be false, if the bits in the two cells are different
-    let equal = if identifier > 0 { true } else { false };
+    let equal = identifier > 0;
     identifier = identifier.abs() - 1 - 9*9*4;
     (
         identifier / (9 * 9 * 9 * 4) + 1,

--- a/src/binary_cnf.rs
+++ b/src/binary_cnf.rs
@@ -2,46 +2,11 @@ pub fn sudoku_to_cnf(clues: &[Vec<Option<i32>>]) -> Vec<Vec<i32>> {
     // each vec inside represents one cnf "statement"
     let mut clauses: Vec<Vec<i32>> = Vec::new();
 
-    // define how equivalence constraints work
-    for row in 1..=9 {
-        for col in 1..=9 {
-            for row2 in 1..=9 {
-                for col2 in 1..=9 {
-                    for bit in 0..4 {
-                        clauses.push(vec![
-                            -eq_cnf_identifier(row, col, row2, col2, bit),
-                            cnf_identifier(row, col, bit),
-                            -cnf_identifier(row2, col2, bit),
-                        ]);
-                        
-                        clauses.push(vec![
-                            -eq_cnf_identifier(row, col, row2, col2, bit),
-                            -cnf_identifier(row, col, bit),
-                            cnf_identifier(row2, col2, bit),
-                        ]);
-                        
-                        clauses.push(vec![
-                            eq_cnf_identifier(row, col, row2, col2, bit),
-                            -cnf_identifier(row, col, bit),
-                            -cnf_identifier(row2, col2, bit),
-                        ]);
-                        
-                        clauses.push(vec![
-                            eq_cnf_identifier(row, col, row2, col2, bit),
-                            cnf_identifier(row, col, bit),
-                            cnf_identifier(row2, col2, bit),
-                        ]);
-                        
-                    }
-                }
-            }
-        }
-    }
-
     // every number in each row is different
     for row in 1..=9 {
         for col in 1..=9 {
             for col2 in (col + 1)..=9 {
+                clauses.append(&mut eq_variable_init(row, col, row, col2));
                 clauses.push(vec![
                     -eq_cnf_identifier(row, col, row, col2, 0),
                     -eq_cnf_identifier(row, col, row, col2, 1),
@@ -56,6 +21,7 @@ pub fn sudoku_to_cnf(clues: &[Vec<Option<i32>>]) -> Vec<Vec<i32>> {
     for col in 1..=9 {
         for row in 1..=9 {
             for row2 in (row + 1)..=9 {
+                clauses.append(&mut eq_variable_init(row, col, row2, col));
                 clauses.push(vec![
                     -eq_cnf_identifier(row, col, row2, col, 0),
                     -eq_cnf_identifier(row, col, row2, col, 1),
@@ -75,6 +41,7 @@ pub fn sudoku_to_cnf(clues: &[Vec<Option<i32>>]) -> Vec<Vec<i32>> {
                     let col = 1 + subgrid_col * 3 + index1 / 3;
                     let row2 = 1 + subgrid_row * 3 + index2 % 3;
                     let col2 = 1 + subgrid_col * 3 + index2 / 3;
+                    clauses.append(&mut eq_variable_init(row, col, row2, col2));
                     clauses.push(vec![
                                  -eq_cnf_identifier(row, col, row2, col2, 0),
                                  -eq_cnf_identifier(row, col, row2, col2, 1),
@@ -122,6 +89,39 @@ pub fn sudoku_to_cnf(clues: &[Vec<Option<i32>>]) -> Vec<Vec<i32>> {
                 }
             }
         }
+    }
+
+    clauses
+}
+
+/// Initialize variables that indicate 2 cells have same bits in some position
+fn eq_variable_init(row: i32, col: i32, row2: i32, col2: i32) -> Vec<Vec<i32>> {
+    let mut clauses: Vec<Vec<i32>> = Vec::new();
+
+    for bit in 0..4 {
+        clauses.push(vec![
+                     -eq_cnf_identifier(row, col, row2, col2, bit),
+                     cnf_identifier(row, col, bit),
+                     -cnf_identifier(row2, col2, bit),
+        ]);
+
+        clauses.push(vec![
+                     -eq_cnf_identifier(row, col, row2, col2, bit),
+                     -cnf_identifier(row, col, bit),
+                     cnf_identifier(row2, col2, bit),
+        ]);
+
+        clauses.push(vec![
+                     eq_cnf_identifier(row, col, row2, col2, bit),
+                     -cnf_identifier(row, col, bit),
+                     -cnf_identifier(row2, col2, bit),
+        ]);
+
+        clauses.push(vec![
+                     eq_cnf_identifier(row, col, row2, col2, bit),
+                     cnf_identifier(row, col, bit),
+                     cnf_identifier(row2, col2, bit),
+        ]);
     }
 
     clauses

--- a/src/binary_cnf.rs
+++ b/src/binary_cnf.rs
@@ -1,6 +1,110 @@
 use cadical::Solver;
+use egui::{
+    text::{LayoutJob, TextFormat},
+    Color32, FontId
+};
+use crate::{cnf_var::CnfVariable, cadical_wrapper::CadicalCallbackWrapper};
 
-use crate::cadical_wrapper::CadicalCallbackWrapper;
+pub struct BitVar {
+    pub row: i32,
+    pub col: i32,
+    pub bit_index: i32,
+    pub bit_value: bool,
+}
+
+pub struct EqVar {
+    pub row: i32,
+    pub col: i32,
+    pub row2: i32,
+    pub col2: i32,
+    pub bit_index: i32,
+    pub equal: bool,
+}
+
+impl CnfVariable for BitVar {
+    fn new(identifier: i32) -> BitVar {
+        let (row, col, bit_index, bit_value) = identifier_to_tuple(identifier);
+        BitVar { row, col, bit_index, bit_value }
+    }
+
+    fn human_readable(&self, text_job: &mut LayoutJob, large_font: FontId, small_font: FontId, text_color: Color32) {
+        let (lead_char, color) = if self.bit_value {
+            ("B", text_color)
+        } else {
+            ("~B", Color32::RED)
+        };
+
+        text_job.append(
+            &format!("{}{}", lead_char, self.bit_index),
+            0.0,
+            TextFormat {
+                font_id: large_font.clone(),
+                color,
+                ..Default::default()
+            },
+        );
+        text_job.append(
+            &format!("({},{})", self.row, self.col),
+            0.0,
+            TextFormat {
+                font_id: small_font.clone(),
+                color,
+                ..Default::default()
+            },
+        );
+    }
+
+    fn to_cnf(&self) -> i32 {
+        if self.bit_value {
+            cnf_identifier(self.row, self.col, self.bit_index)
+        } else {
+            -cnf_identifier(self.row, self.col, self.bit_index)
+        }
+    }
+}
+
+impl CnfVariable for EqVar {
+    fn new(identifier: i32) -> EqVar {
+        let (row, col, row2, col2, bit_index, equal) = eq_identifier_to_tuple(identifier);
+        EqVar { row, col, row2, col2, bit_index, equal }
+    }
+
+    fn human_readable(&self, text_job: &mut LayoutJob, large_font: FontId, small_font: FontId, text_color: Color32) {
+        let (lead_char, color) = if self.equal {
+            ("EQ", text_color)
+        } else {
+            ("~EQ", Color32::RED)
+        };
+
+        text_job.append(
+            &format!("{}{}", lead_char, self.bit_index),
+            0.0,
+            TextFormat {
+                font_id: large_font.clone(),
+                color,
+                ..Default::default()
+            },
+        );
+        text_job.append(
+            &format!("({},{});({},{})", self.row, self.col, self.row2, self.col2),
+            0.0,
+            TextFormat {
+                font_id: small_font.clone(),
+                color,
+                ..Default::default()
+            },
+        );
+    }
+
+    fn to_cnf(&self) -> i32 {
+        if self.equal {
+            eq_cnf_identifier(self.row, self.col, self.row2, self.col2, self.bit_index)
+        } else {
+            -eq_cnf_identifier(self.row, self.col, self.row2, self.col2, self.bit_index)
+        }
+    }
+}
+
 
 #[allow(dead_code)]
 pub fn sudoku_to_cnf(clues: &[Vec<Option<i32>>]) -> Vec<Vec<i32>> {
@@ -164,7 +268,7 @@ pub fn eq_cnf_identifier(row: i32, col: i32, row2: i32, col2: i32, bit: i32) -> 
 /// These do not work for the new encoding YET, which is why they are not used YET
 #[allow(dead_code)]
 #[inline(always)]
-pub fn identifier_to_tuple(mut identifier: i32) -> (i32, i32, i32, bool) {
+fn identifier_to_tuple(mut identifier: i32) -> (i32, i32, i32, bool) {
     // Reverse CNF-identifier creation
     // Return tuple of (row, col, bit_index, bit_value) from identifier
     // bit_value will be false for negative ids, positive otherwise
@@ -179,7 +283,7 @@ pub fn identifier_to_tuple(mut identifier: i32) -> (i32, i32, i32, bool) {
 }
 
 #[allow(dead_code)]
-pub fn eq_identifier_to_tuple(mut identifier: i32) -> (i32, i32, i32, i32, i32, bool) {
+fn eq_identifier_to_tuple(mut identifier: i32) -> (i32, i32, i32, i32, i32, bool) {
     // Reverse CNF-identifier creation for equality constraints
     // Return tuple of (row, col, row2, col2, bit_index, equal) from identifier
     // equal will be false, if the bits in the two cells are different

--- a/src/binary_cnf.rs
+++ b/src/binary_cnf.rs
@@ -155,8 +155,8 @@ pub fn eq_cnf_identifier(row: i32, col: i32, row2: i32, col2: i32, bit: i32) -> 
     9 * 9 * 4
         + (row - 1) * 4 * 9 * 9 * 9
         + (col - 1) * 4 * 9 * 9
-        + (row2 - 1)* 4 * 9 
-        + (col2 - 1)* 4
+        + (row2 - 1) * 4 * 9
+        + (col2 - 1) * 4
         + bit
         + 1
 }
@@ -184,7 +184,7 @@ pub fn eq_identifier_to_tuple(mut identifier: i32) -> (i32, i32, i32, i32, i32, 
     // Return tuple of (row, col, row2, col2, bit_index, equal) from identifier
     // equal will be false, if the bits in the two cells are different
     let equal = identifier > 0;
-    identifier = identifier.abs() - 1 - 9*9*4;
+    identifier = identifier.abs() - 1 - 9 * 9 * 4;
     (
         identifier / (9 * 9 * 9 * 4) + 1,
         (identifier % (9 * 9 * 9 * 4)) / (4 * 9 * 9) + 1,
@@ -193,11 +193,12 @@ pub fn eq_identifier_to_tuple(mut identifier: i32) -> (i32, i32, i32, i32, i32, 
         (identifier % 4),
         equal,
     )
-
 }
 
 #[allow(dead_code)]
-pub fn create_tuples_from_constraints(constraints: Vec<Vec<i32>>) -> Vec<Vec<(i32, i32, i32, bool)>> {
+pub fn create_tuples_from_constraints(
+    constraints: Vec<Vec<i32>>,
+) -> Vec<Vec<(i32, i32, i32, bool)>> {
     let mut tuples = Vec::new();
     for constraint in constraints.iter() {
         let mut temp = Vec::with_capacity(constraint.len());
@@ -242,9 +243,18 @@ mod tests {
 
     #[test]
     fn test_to_id_and_back() {
-        assert_eq!((1, 1, 0, true), identifier_to_tuple(cnf_identifier(1, 1, 0)));
-        assert_eq!((1, 2, 3, true), identifier_to_tuple(cnf_identifier(1, 2, 3)));
-        assert_eq!((9, 9, 3, true), identifier_to_tuple(cnf_identifier(9, 9, 3)));
+        assert_eq!(
+            (1, 1, 0, true),
+            identifier_to_tuple(cnf_identifier(1, 1, 0))
+        );
+        assert_eq!(
+            (1, 2, 3, true),
+            identifier_to_tuple(cnf_identifier(1, 2, 3))
+        );
+        assert_eq!(
+            (9, 9, 3, true),
+            identifier_to_tuple(cnf_identifier(9, 9, 3))
+        );
         assert_eq!(
             (6, 2, 0, false),
             identifier_to_tuple(-1 * cnf_identifier(6, 2, 0))
@@ -253,9 +263,18 @@ mod tests {
 
     #[test]
     fn test_to_eq_id_and_back() {
-        assert_eq!((1, 1, 1, 1, 0, true), eq_identifier_to_tuple(eq_cnf_identifier(1, 1, 1, 1, 0)));
-        assert_eq!((1, 2, 3, 4, 0, true), eq_identifier_to_tuple(eq_cnf_identifier(1, 2, 3, 4, 0)));
-        assert_eq!((9, 9, 9, 9, 3, true), eq_identifier_to_tuple(eq_cnf_identifier(9, 9, 9, 9, 3)));
+        assert_eq!(
+            (1, 1, 1, 1, 0, true),
+            eq_identifier_to_tuple(eq_cnf_identifier(1, 1, 1, 1, 0))
+        );
+        assert_eq!(
+            (1, 2, 3, 4, 0, true),
+            eq_identifier_to_tuple(eq_cnf_identifier(1, 2, 3, 4, 0))
+        );
+        assert_eq!(
+            (9, 9, 9, 9, 3, true),
+            eq_identifier_to_tuple(eq_cnf_identifier(9, 9, 9, 9, 3))
+        );
         assert_eq!(
             (6, 2, 8, 2, 0, false),
             eq_identifier_to_tuple(-1 * eq_cnf_identifier(6, 2, 8, 2, 0))

--- a/src/binary_cnf.rs
+++ b/src/binary_cnf.rs
@@ -71,10 +71,10 @@ pub fn sudoku_to_cnf(clues: &[Vec<Option<i32>>]) -> Vec<Vec<i32>> {
         for subgrid_col in 0..=2 {
             for index1 in 0..9 {
                 for index2 in (index1 + 1)..9 {
-                    let row = subgrid_row * 3 + index1 % 3;
-                    let col = subgrid_col * 3 + index1 / 3;
-                    let row2 = subgrid_row * 3 + index2 % 3;
-                    let col2 = subgrid_col * 3 + index2 / 3;
+                    let row = 1 + subgrid_row * 3 + index1 % 3;
+                    let col = 1 + subgrid_col * 3 + index1 / 3;
+                    let row2 = 1 + subgrid_row * 3 + index2 % 3;
+                    let col2 = 1 + subgrid_col * 3 + index2 / 3;
                     clauses.push(vec![
                                  -eq_cnf_identifier(row, col, row2, col2, 0),
                                  -eq_cnf_identifier(row, col, row2, col2, 1),
@@ -89,15 +89,15 @@ pub fn sudoku_to_cnf(clues: &[Vec<Option<i32>>]) -> Vec<Vec<i32>> {
     // no numbers > 9
     for row in 1..=9 {
         for col in 1..=9 {
-            for forbidden in 9..15 {
+            for forbidden in 9..16 {
                 let mut cell_clause = Vec::with_capacity(4);
                 let mut mask = 1;
                 for index in 0..4 {
                     // Here we invert the bits, since we do not want to allow the forbidden numbers
                     if (forbidden & mask) != 0 {
-                        cell_clause.push(-cnf_identifier(row as i32 + 1, col as i32 + 1, index));
+                        cell_clause.push(-cnf_identifier(row as i32, col as i32, index));
                     } else {
-                        cell_clause.push(cnf_identifier(row as i32 + 1, col as i32 + 1, index));
+                        cell_clause.push(cnf_identifier(row as i32, col as i32, index));
                     }
                     mask *= 2;
                 }

--- a/src/binary_cnf.rs
+++ b/src/binary_cnf.rs
@@ -1,0 +1,117 @@
+use crate::error::GenericError;
+
+pub fn sudoku_to_cnf(clues: &[Vec<Option<i32>>]) -> Vec<Vec<i32>> {
+    // each vec inside represents one cnf "statement"
+    let mut clauses: Vec<Vec<i32>> = Vec::new();
+
+    // each cell has at least one value
+    for row in 1..=9 {
+        for col in 1..=9 {
+            let mut cell_cnf: Vec<i32> = Vec::with_capacity(9);
+            for val in 1..=9 {
+                cell_cnf.push(cnf_identifier(row, col, val));
+            }
+            clauses.push(cell_cnf);
+        }
+    }
+
+    // each cell has at most one value
+    for row in 1..=9 {
+        for col in 1..=9 {
+            for val1 in 1..=8 {
+                for val2 in (val1 + 1)..=9 {
+                    let cell_cnf = vec![
+                        -cnf_identifier(row, col, val1),
+                        -cnf_identifier(row, col, val2),
+                    ];
+                    clauses.push(cell_cnf);
+                }
+            }
+        }
+    }
+
+    // each row has all the numbers
+    for val in 1..=9 {
+        for row in 1..=9 {
+            let mut row_cnf: Vec<i32> = Vec::with_capacity(9);
+            for col in 1..=9 {
+                row_cnf.push(cnf_identifier(row, col, val));
+            }
+            clauses.push(row_cnf);
+        }
+    }
+
+    // each column has all the numbers
+    for val in 1..=9 {
+        for col in 1..=9 {
+            let mut col_cnf: Vec<i32> = Vec::with_capacity(9);
+            for row in 1..=9 {
+                col_cnf.push(cnf_identifier(row, col, val));
+            }
+            clauses.push(col_cnf);
+        }
+    }
+
+    // each sub-grid has all the numbers
+    for subgrid_row in 0..=2 {
+        for subgrid_col in 0..=2 {
+            for val in 1..=9 {
+                let mut subgrid_cnf: Vec<i32> = Vec::with_capacity(9);
+                for row in 1..=3 {
+                    for col in 1..=3 {
+                        subgrid_cnf.push(cnf_identifier(
+                            row + 3 * subgrid_row,
+                            col + 3 * subgrid_col,
+                            val,
+                        ));
+                    }
+                }
+                clauses.push(subgrid_cnf);
+            }
+        }
+    }
+
+    // respect all the clues
+    for (row, line) in clues.iter().enumerate() {
+        for (col, val) in line.iter().enumerate() {
+            if let Some(val) = val {
+                clauses.push(vec![cnf_identifier(row as i32 + 1, col as i32 + 1, *val)]);
+            }
+        }
+    }
+
+    clauses
+}
+
+#[inline(always)]
+pub fn cnf_identifier(row: i32, col: i32, bit: i32) -> i32 {
+    // Creates cnf identifier from sudoku based on row, column and value
+    // So every row, column and value combination has a unique identifier
+    (row - 1) * 4 * 9 + (col - 1) * 4 + bit
+}
+
+#[inline(always)]
+pub fn identifier_to_tuple(mut identifier: i32) -> (i32, i32, i32) {
+    // Reverse CNF-identifier creation
+    // Return tuple of (row, col, val) from identifier
+    // Val will be negative for negative ids, positive otherwise
+    let negation_multiplier = if identifier > 0 { 1 } else { -1 };
+    identifier = identifier.abs() - 1;
+    (
+        identifier / (9 * 4) + 1,
+        (identifier % (9 * 4)) / 4 + 1,
+        negation_multiplier * (identifier % 4 + 1),
+    )
+}
+
+pub fn create_tuples_from_constraints(constraints: Vec<Vec<i32>>) -> Vec<Vec<(i32, i32, i32)>> {
+    let mut tuples = Vec::new();
+    for constraint in constraints.iter() {
+        let mut temp = Vec::with_capacity(constraint.len());
+        for value in constraint {
+            temp.push(identifier_to_tuple(*value));
+        }
+        tuples.push(temp);
+    }
+    tuples
+}

--- a/src/binary_cnf.rs
+++ b/src/binary_cnf.rs
@@ -89,7 +89,7 @@ pub fn sudoku_to_cnf(clues: &[Vec<Option<i32>>]) -> Vec<Vec<i32>> {
     // no numbers > 9
     for row in 1..=9 {
         for col in 1..=9 {
-            for forbidden in 10..16 {
+            for forbidden in 9..15 {
                 let mut cell_clause = Vec::with_capacity(4);
                 let mut mask = 1;
                 for index in 0..4 {
@@ -103,13 +103,6 @@ pub fn sudoku_to_cnf(clues: &[Vec<Option<i32>>]) -> Vec<Vec<i32>> {
                 }
                 clauses.push(cell_clause);
             }
-            // forbid 0 separately
-            clauses.push(vec![
-                         cnf_identifier(row as i32 + 1, col as i32 + 1, 0),
-                         cnf_identifier(row as i32 + 1, col as i32 + 1, 1),
-                         cnf_identifier(row as i32 + 1, col as i32 + 1, 2),
-                         cnf_identifier(row as i32 + 1, col as i32 + 1, 3),
-            ]);
         }
     }
 
@@ -137,7 +130,7 @@ pub fn sudoku_to_cnf(clues: &[Vec<Option<i32>>]) -> Vec<Vec<i32>> {
 pub fn cnf_identifier(row: i32, col: i32, bit: i32) -> i32 {
     // Creates cnf identifier from sudoku based on row, column and value
     // So every row, column and value combination has a unique identifier
-    (row - 1) * 4 * 9 + (col - 1) * 4 + bit
+    (row - 1) * 4 * 9 + (col - 1) * 4 + bit + 1
 }
 
 #[inline(always)]
@@ -148,6 +141,7 @@ pub fn eq_cnf_identifier(row: i32, col: i32, row2: i32, col2: i32, bit: i32) -> 
         + (row2 - 1) * 4 * 9 * 9 * 9
         + (col2 - 1) * 4 * 9 * 9
         + bit
+        + 1
 }
 
 #[inline(always)]

--- a/src/binary_cnf.rs
+++ b/src/binary_cnf.rs
@@ -1,73 +1,115 @@
-use crate::error::GenericError;
-
 pub fn sudoku_to_cnf(clues: &[Vec<Option<i32>>]) -> Vec<Vec<i32>> {
     // each vec inside represents one cnf "statement"
     let mut clauses: Vec<Vec<i32>> = Vec::new();
 
-    // each cell has at least one value
+    // define how equivalence constraints work
     for row in 1..=9 {
         for col in 1..=9 {
-            let mut cell_cnf: Vec<i32> = Vec::with_capacity(9);
-            for val in 1..=9 {
-                cell_cnf.push(cnf_identifier(row, col, val));
-            }
-            clauses.push(cell_cnf);
-        }
-    }
-
-    // each cell has at most one value
-    for row in 1..=9 {
-        for col in 1..=9 {
-            for val1 in 1..=8 {
-                for val2 in (val1 + 1)..=9 {
-                    let cell_cnf = vec![
-                        -cnf_identifier(row, col, val1),
-                        -cnf_identifier(row, col, val2),
-                    ];
-                    clauses.push(cell_cnf);
+            for row2 in 1..=9 {
+                for col2 in 1..=9 {
+                    for bit in 0..4 {
+                        clauses.push(vec![
+                            -eq_cnf_identifier(row, col, row2, col2, bit),
+                            cnf_identifier(row, col, bit),
+                            -cnf_identifier(row2, col2, bit),
+                        ]);
+                        
+                        clauses.push(vec![
+                            -eq_cnf_identifier(row, col, row2, col2, bit),
+                            -cnf_identifier(row, col, bit),
+                            cnf_identifier(row2, col2, bit),
+                        ]);
+                        
+                        clauses.push(vec![
+                            eq_cnf_identifier(row, col, row2, col2, bit),
+                            -cnf_identifier(row, col, bit),
+                            -cnf_identifier(row2, col2, bit),
+                        ]);
+                        
+                        clauses.push(vec![
+                            eq_cnf_identifier(row, col, row2, col2, bit),
+                            cnf_identifier(row, col, bit),
+                            cnf_identifier(row2, col2, bit),
+                        ]);
+                        
+                    }
                 }
             }
         }
     }
 
-    // each row has all the numbers
-    for val in 1..=9 {
-        for row in 1..=9 {
-            let mut row_cnf: Vec<i32> = Vec::with_capacity(9);
-            for col in 1..=9 {
-                row_cnf.push(cnf_identifier(row, col, val));
+    // every number in each row is different
+    for row in 1..=9 {
+        for col in 1..=9 {
+            for col2 in (col + 1)..=9 {
+                clauses.push(vec![
+                    -eq_cnf_identifier(row, col, row, col2, 0),
+                    -eq_cnf_identifier(row, col, row, col2, 1),
+                    -eq_cnf_identifier(row, col, row, col2, 2),
+                    -eq_cnf_identifier(row, col, row, col2, 3),
+                ]);
             }
-            clauses.push(row_cnf);
         }
     }
 
-    // each column has all the numbers
-    for val in 1..=9 {
-        for col in 1..=9 {
-            let mut col_cnf: Vec<i32> = Vec::with_capacity(9);
-            for row in 1..=9 {
-                col_cnf.push(cnf_identifier(row, col, val));
+    // every number in each col is different
+    for col in 1..=9 {
+        for row in 1..=9 {
+            for row2 in (row + 1)..=9 {
+                clauses.push(vec![
+                    -eq_cnf_identifier(row, col, row2, col, 0),
+                    -eq_cnf_identifier(row, col, row2, col, 1),
+                    -eq_cnf_identifier(row, col, row2, col, 2),
+                    -eq_cnf_identifier(row, col, row2, col, 3),
+                ]);
             }
-            clauses.push(col_cnf);
         }
     }
 
     // each sub-grid has all the numbers
     for subgrid_row in 0..=2 {
         for subgrid_col in 0..=2 {
-            for val in 1..=9 {
-                let mut subgrid_cnf: Vec<i32> = Vec::with_capacity(9);
-                for row in 1..=3 {
-                    for col in 1..=3 {
-                        subgrid_cnf.push(cnf_identifier(
-                            row + 3 * subgrid_row,
-                            col + 3 * subgrid_col,
-                            val,
-                        ));
-                    }
+            for index1 in 0..9 {
+                for index2 in (index1 + 1)..9 {
+                    let row = subgrid_row * 3 + index1 % 3;
+                    let col = subgrid_col * 3 + index1 / 3;
+                    let row2 = subgrid_row * 3 + index2 % 3;
+                    let col2 = subgrid_col * 3 + index2 / 3;
+                    clauses.push(vec![
+                                 -eq_cnf_identifier(row, col, row2, col2, 0),
+                                 -eq_cnf_identifier(row, col, row2, col2, 1),
+                                 -eq_cnf_identifier(row, col, row2, col2, 2),
+                                 -eq_cnf_identifier(row, col, row2, col2, 3),
+                    ]);
+
                 }
-                clauses.push(subgrid_cnf);
             }
+        }
+    }
+    // no numbers > 9
+    for row in 1..=9 {
+        for col in 1..=9 {
+            for forbidden in 10..16 {
+                let mut cell_clause = Vec::with_capacity(4);
+                let mut mask = 1;
+                for index in 0..4 {
+                    // Here we invert the bits, since we do not want to allow the forbidden numbers
+                    if (forbidden & mask) != 0 {
+                        cell_clause.push(-cnf_identifier(row as i32 + 1, col as i32 + 1, index));
+                    } else {
+                        cell_clause.push(cnf_identifier(row as i32 + 1, col as i32 + 1, index));
+                    }
+                    mask *= 2;
+                }
+                clauses.push(cell_clause);
+            }
+            // forbid 0 separately
+            clauses.push(vec![
+                         cnf_identifier(row as i32 + 1, col as i32 + 1, 0),
+                         cnf_identifier(row as i32 + 1, col as i32 + 1, 1),
+                         cnf_identifier(row as i32 + 1, col as i32 + 1, 2),
+                         cnf_identifier(row as i32 + 1, col as i32 + 1, 3),
+            ]);
         }
     }
 
@@ -75,7 +117,15 @@ pub fn sudoku_to_cnf(clues: &[Vec<Option<i32>>]) -> Vec<Vec<i32>> {
     for (row, line) in clues.iter().enumerate() {
         for (col, val) in line.iter().enumerate() {
             if let Some(val) = val {
-                clauses.push(vec![cnf_identifier(row as i32 + 1, col as i32 + 1, *val)]);
+                let mut mask = 1;
+                for index in 0..4 {
+                    if (val & mask) != 0 {
+                        clauses.push(vec![cnf_identifier(row as i32 + 1, col as i32 + 1, index)]);
+                    } else {
+                        clauses.push(vec![-cnf_identifier(row as i32 + 1, col as i32 + 1, index)]);
+                    }
+                    mask *= 2;
+                }
             }
         }
     }
@@ -88,6 +138,16 @@ pub fn cnf_identifier(row: i32, col: i32, bit: i32) -> i32 {
     // Creates cnf identifier from sudoku based on row, column and value
     // So every row, column and value combination has a unique identifier
     (row - 1) * 4 * 9 + (col - 1) * 4 + bit
+}
+
+#[inline(always)]
+pub fn eq_cnf_identifier(row: i32, col: i32, row2: i32, col2: i32, bit: i32) -> i32 {
+    9 * 9 * 4
+        + (row - 1) * 4 * 9
+        + (col - 1) * 4
+        + (row2 - 1) * 4 * 9 * 9 * 9
+        + (col2 - 1) * 4 * 9 * 9
+        + bit
 }
 
 #[inline(always)]

--- a/src/binary_cnf.rs
+++ b/src/binary_cnf.rs
@@ -109,7 +109,8 @@ pub fn sudoku_to_cnf(clues: &[Vec<Option<i32>>]) -> Vec<Vec<i32>> {
     // respect all the clues
     for (row, line) in clues.iter().enumerate() {
         for (col, val) in line.iter().enumerate() {
-            if let Some(val) = val {
+            if let Some(mut val) = val {
+                val -= 1;
                 let mut mask = 1;
                 for index in 0..4 {
                     if (val & mask) != 0 {

--- a/src/binary_cnf.rs
+++ b/src/binary_cnf.rs
@@ -1,9 +1,9 @@
+use crate::{cadical_wrapper::CadicalCallbackWrapper, cnf_var::CnfVariable};
 use cadical::Solver;
 use egui::{
     text::{LayoutJob, TextFormat},
-    Color32, FontId
+    Color32, FontId,
 };
-use crate::{cnf_var::CnfVariable, cadical_wrapper::CadicalCallbackWrapper};
 
 pub struct BitVar {
     pub row: i32,
@@ -24,10 +24,21 @@ pub struct EqVar {
 impl CnfVariable for BitVar {
     fn new(identifier: i32) -> BitVar {
         let (row, col, bit_index, bit_value) = identifier_to_tuple(identifier);
-        BitVar { row, col, bit_index, bit_value }
+        BitVar {
+            row,
+            col,
+            bit_index,
+            bit_value,
+        }
     }
 
-    fn human_readable(&self, text_job: &mut LayoutJob, large_font: FontId, small_font: FontId, text_color: Color32) {
+    fn human_readable(
+        &self,
+        text_job: &mut LayoutJob,
+        large_font: FontId,
+        small_font: FontId,
+        text_color: Color32,
+    ) {
         let (lead_char, color) = if self.bit_value {
             ("B", text_color)
         } else {
@@ -66,10 +77,23 @@ impl CnfVariable for BitVar {
 impl CnfVariable for EqVar {
     fn new(identifier: i32) -> EqVar {
         let (row, col, row2, col2, bit_index, equal) = eq_identifier_to_tuple(identifier);
-        EqVar { row, col, row2, col2, bit_index, equal }
+        EqVar {
+            row,
+            col,
+            row2,
+            col2,
+            bit_index,
+            equal,
+        }
     }
 
-    fn human_readable(&self, text_job: &mut LayoutJob, large_font: FontId, small_font: FontId, text_color: Color32) {
+    fn human_readable(
+        &self,
+        text_job: &mut LayoutJob,
+        large_font: FontId,
+        small_font: FontId,
+        text_color: Color32,
+    ) {
         let (lead_char, color) = if self.equal {
             ("EQ", text_color)
         } else {
@@ -104,7 +128,6 @@ impl CnfVariable for EqVar {
         }
     }
 }
-
 
 #[allow(dead_code)]
 pub fn sudoku_to_cnf(clues: &[Vec<Option<i32>>]) -> Vec<Vec<i32>> {

--- a/src/cnf_converter.rs
+++ b/src/cnf_converter.rs
@@ -1,4 +1,6 @@
-use crate::error::GenericError;
+use cadical::Solver;
+
+use crate::{cadical_wrapper::CadicalCallbackWrapper, error::GenericError};
 
 pub fn sudoku_to_cnf(clues: &[Vec<Option<i32>>]) -> Vec<Vec<i32>> {
     // each vec inside represents one cnf "statement"
@@ -146,6 +148,15 @@ pub fn clues_from_string(
     }
 
     Ok(clues)
+}
+
+pub fn get_cell_value(solver: &Solver<CadicalCallbackWrapper>, row: i32, col: i32) -> i32 {
+    for val in 1..=9 {
+        if solver.value(cnf_identifier(row, col, val)).unwrap() {
+            return val;
+        }
+    }
+    -1
 }
 
 #[cfg(test)]

--- a/src/cnf_converter.rs
+++ b/src/cnf_converter.rs
@@ -1,7 +1,7 @@
 use cadical::Solver;
 use egui::{
     text::{LayoutJob, TextFormat},
-    Color32, FontId
+    Color32, FontId,
 };
 
 use crate::{cadical_wrapper::CadicalCallbackWrapper, cnf_var::CnfVariable, error::GenericError};
@@ -18,7 +18,13 @@ impl CnfVariable for DecimalVar {
         DecimalVar { row, col, val }
     }
 
-    fn human_readable(&self, text_job: &mut LayoutJob, large_font: FontId, small_font: FontId, text_color: Color32) {
+    fn human_readable(
+        &self,
+        text_job: &mut LayoutJob,
+        large_font: FontId,
+        small_font: FontId,
+        text_color: Color32,
+    ) {
         let (lead_char, color) = if self.val > 0 {
             ("", text_color)
         } else {

--- a/src/cnf_var.rs
+++ b/src/cnf_var.rs
@@ -1,0 +1,12 @@
+use egui::{
+    text::LayoutJob,
+    Color32, FontId
+};
+
+pub trait CnfVariable {
+    fn new(identifier: i32) -> Self;
+
+    fn human_readable(&self, text_job: &mut LayoutJob, large_font: FontId, small_font: FontId, text_color: Color32);
+
+    fn to_cnf(&self) -> i32; 
+}

--- a/src/cnf_var.rs
+++ b/src/cnf_var.rs
@@ -1,12 +1,15 @@
-use egui::{
-    text::LayoutJob,
-    Color32, FontId
-};
+use egui::{text::LayoutJob, Color32, FontId};
 
 pub trait CnfVariable {
     fn new(identifier: i32) -> Self;
 
-    fn human_readable(&self, text_job: &mut LayoutJob, large_font: FontId, small_font: FontId, text_color: Color32);
+    fn human_readable(
+        &self,
+        text_job: &mut LayoutJob,
+        large_font: FontId,
+        small_font: FontId,
+        text_color: Color32,
+    );
 
-    fn to_cnf(&self) -> i32; 
+    fn to_cnf(&self) -> i32;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub fn solve_sudoku(
         for row in 1..=9 {
             let mut row_values = Vec::with_capacity(9);
             for col in 1..=9 {
-                let mut value: i32 = 0;
+                let mut value: i32 = 1;
                 for bit in 0..4 {
                     if solver.value(cnf_identifier(row, col, bit)).unwrap() {
                         value += (2 as i32).pow(bit as u32);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod cadical_wrapper;
 mod cnf_converter;
 mod error;
 mod filtering;
+mod cnf_var;
 pub mod gui;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,8 @@ use cadical::Solver;
 
 use cadical_wrapper::CadicalCallbackWrapper;
 use cnf_converter::clues_from_string;
-use binary_cnf::{sudoku_to_cnf, cnf_identifier};
+// use binary_cnf::{sudoku_to_cnf, get_cell_value};
+use cnf_converter::{get_cell_value, sudoku_to_cnf};
 use error::GenericError;
 
 /// Rc<RefCell<Vec<Vec<i32>>>> is used to store the learned cnf_clauses
@@ -78,12 +79,7 @@ pub fn solve_sudoku(
         for row in 1..=9 {
             let mut row_values = Vec::with_capacity(9);
             for col in 1..=9 {
-                let mut value: i32 = 1;
-                for bit in 0..4 {
-                    if solver.value(cnf_identifier(row, col, bit)).unwrap() {
-                        value += (2 as i32).pow(bit as u32);
-                    }
-                }
+                let value = get_cell_value(solver, row, col);
                 row_values.push(Some(value));
             }
             solved.push(row_values);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod app_state;
+mod binary_cnf;
 mod cadical_wrapper;
 mod cnf_converter;
 mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,9 @@ mod app_state;
 mod binary_cnf;
 mod cadical_wrapper;
 mod cnf_converter;
+mod cnf_var;
 mod error;
 mod filtering;
-mod cnf_var;
 pub mod gui;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,8 @@ use std::{cell::RefCell, fs, num::ParseIntError, rc::Rc};
 use cadical::Solver;
 
 use cadical_wrapper::CadicalCallbackWrapper;
-use cnf_converter::{clues_from_string, cnf_identifier, sudoku_to_cnf};
+use cnf_converter::clues_from_string;
+use binary_cnf::{sudoku_to_cnf, cnf_identifier};
 use error::GenericError;
 
 /// Rc<RefCell<Vec<Vec<i32>>>> is used to store the learned cnf_clauses
@@ -77,12 +78,13 @@ pub fn solve_sudoku(
         for row in 1..=9 {
             let mut row_values = Vec::with_capacity(9);
             for col in 1..=9 {
-                for val in 1..=9 {
-                    if solver.value(cnf_identifier(row, col, val)).unwrap() {
-                        row_values.push(Some(val));
-                        break;
+                let mut value: i32 = 0;
+                for bit in 0..4 {
+                    if solver.value(cnf_identifier(row, col, bit)).unwrap() {
+                        value += (2 as i32).pow(bit as u32);
                     }
                 }
+                row_values.push(Some(value));
             }
             solved.push(row_values);
         }


### PR DESCRIPTION
Add functioning bit CNF encoding, which is currently unused, because the rest of the program is not ready for it. PR made now to limit the size of any individual PR.

The actual solving with the new encoding can be tested by commenting out the line
`use cnf_converter::{get_cell_value, sudoku_to_cnf};`
and uncommenting the line
`// use binary_cnf::{sudoku_to_cnf, get_cell_value};`
at the top of `lib.rs`.

[Explanation of new encoding](https://docs.google.com/document/u/0/d/1VMQQ-wGp8Ji-V3uGQBcjKqTwO-OnSFk2WjuArnd57Fk/mobilebasic)