### PR TITLE
Key input merge

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -131,6 +131,10 @@ impl AppState {
             .filter
             .get_little_number_constraints(self.page_number as usize, self.page_length);
     }
+
+    pub fn quit(&mut self) {
+        std::process::exit(0);
+    }
 }
 
 #[cfg(test)]

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -111,7 +111,7 @@ impl eframe::App for SATApp {
                 ui.columns(2, |columns| {
                     columns[0].vertical_centered(|ui| {
                         self.controls(ui, width, ctx);
-                        self.constraint_list(ui, width);
+                        self.constraint_list(ui, ctx, width);
                     });
                     columns[1].vertical_centered(|ui| {
                         self.sudoku_grid(ui, height, width);

--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -1,6 +1,6 @@
 use egui::{
     text::{LayoutJob, TextFormat},
-    Color32, FontId, Label, NumExt, Rect, Response, RichText, ScrollArea, TextStyle, Ui, Vec2
+    Color32, FontId, Key, Label, NumExt, Rect, Response, RichText, ScrollArea, TextStyle, Ui, Vec2,
 };
 use std::ops::Add;
 
@@ -20,7 +20,7 @@ impl SATApp {
                 self.learned_constraints_labels(ui, text_scale);
                 ui.end_row();
             });
-        self.list_of_constraints(ui, text_scale).response
+        self.list_of_constraints(ui, text_scale, ctx).response
     }
 
     fn learned_constraints_labels(
@@ -50,7 +50,12 @@ impl SATApp {
         })
     }
 
-    fn list_of_constraints(&mut self, ui: &mut Ui, text_scale: f32) -> egui::InnerResponse<()> {
+    fn list_of_constraints(
+        &mut self,
+        ui: &mut Ui,
+        text_scale: f32,
+        ctx: &egui::Context,
+    ) -> egui::InnerResponse<()> {
         ui.vertical(|ui| {
             ScrollArea::both()
                 .auto_shrink([false; 2])
@@ -173,6 +178,21 @@ impl SATApp {
                             // Text itself
                             ui.painter().galley(egui::pos2(x, y), galley);
                         }
+                    }
+
+                    let current_constraint_row: usize =
+                        self.state.clicked_constraint_index.unwrap_or(0);
+                    if ctx.input(|i| i.key_pressed(Key::ArrowDown))
+                        && (current_constraint_row < self.state.filtered_length - 1)
+                        && current_constraint_row % self.state.page_length
+                            < self.state.page_length - 1
+                    {
+                        self.state.clicked_constraint_index = Some(current_constraint_row + 1);
+                        println!("Go to line number {}", current_constraint_row + 1 + 1)
+                    }
+                    if ctx.input(|i| i.key_pressed(Key::ArrowUp)) && (current_constraint_row > 0) {
+                        self.state.clicked_constraint_index = Some(current_constraint_row - 1);
+                        println!("Go to line number {}", current_constraint_row - 1 + 1)
                     }
                 });
         })

--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -1,6 +1,6 @@
 use egui::{
     text::{LayoutJob, TextFormat},
-    Color32, FontId, Key, Label, NumExt, Rect, Response, RichText, ScrollArea, TextStyle, Ui, Vec2,
+    Color32, FontId, Key, Label, NumExt, Rect, Response, RichText, ScrollArea, TextStyle, Ui, Vec2, Align,
 };
 use std::ops::Add;
 
@@ -205,12 +205,19 @@ impl SATApp {
                     {
                         current_constraint_row += 1;
                         self.state.clicked_constraint_index = Some(current_constraint_row);
+                        // Check how far down the visible list currently and keep in view
+                        if current_constraint_row > last_item - 4 {
+                        // Scroll down with the selection
+                        ui.scroll_with_delta(Vec2::new(0.0,row_height*-1.0));
+                        }
                     }
 
                     // Actions when a constraint row is clicked with the ArrowUp button
                     if ctx.input(|i| i.key_pressed(Key::ArrowUp)) && (current_constraint_row > 0) {
                         current_constraint_row -= 1;
                         self.state.clicked_constraint_index = Some(current_constraint_row);
+                        // Scroll up with the selection
+                        ui.scroll_with_delta(Vec2::new(0.0,row_height));
                     }
                 });
         })

--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -1,6 +1,6 @@
 use egui::{
     text::{LayoutJob, TextFormat},
-    Color32, FontId, Key, Label, NumExt, Rect, Response, RichText, ScrollArea, TextStyle, Ui, Vec2, Align,
+    Color32, FontId, Key, Label, NumExt, Rect, Response, RichText, ScrollArea, TextStyle, Ui, Vec2,
 };
 use std::ops::Add;
 
@@ -195,6 +195,8 @@ impl SATApp {
                             - ((self.state.page_count as usize - 1) * self.state.page_length)
                             - 1;
                     }
+                    
+                    let mut scroll_delta = Vec2::ZERO;
 
                     // Actions when a constraint row is clicked with the ArrowDown button
                     if ctx.input(|i| i.key_pressed(Key::ArrowDown))
@@ -206,9 +208,9 @@ impl SATApp {
                         current_constraint_row += 1;
                         self.state.clicked_constraint_index = Some(current_constraint_row);
                         // Check how far down the visible list currently and keep in view
-                        if current_constraint_row > last_item - 4 {
+                        if current_constraint_row > last_item - 5 {
                         // Scroll down with the selection
-                        ui.scroll_with_delta(Vec2::new(0.0,row_height*-1.0));
+                            scroll_delta.y -= row_height;
                         }
                     }
 
@@ -217,8 +219,9 @@ impl SATApp {
                         current_constraint_row -= 1;
                         self.state.clicked_constraint_index = Some(current_constraint_row);
                         // Scroll up with the selection
-                        ui.scroll_with_delta(Vec2::new(0.0,row_height));
+                        scroll_delta.y += row_height;
                     }
+                    ui.scroll_with_delta(scroll_delta);
                 });
         })
     }

--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -195,7 +195,7 @@ impl SATApp {
                             - ((self.state.page_count as usize - 1) * self.state.page_length)
                             - 1;
                     }
-                    
+
                     let mut scroll_delta = Vec2::ZERO;
 
                     if self.state.clicked_constraint_index.is_some() {
@@ -210,13 +210,15 @@ impl SATApp {
                             self.state.clicked_constraint_index = Some(current_constraint_row);
                             // Check how far down the visible list currently and keep in view
                             if current_constraint_row > last_item - 5 {
-                            // Scroll down with the selection
+                                // Scroll down with the selection
                                 scroll_delta.y -= row_height;
                             }
                         }
 
                         // Actions when a constraint row is clicked with the ArrowUp button
-                        if ctx.input(|i| i.key_pressed(Key::ArrowUp)) && (current_constraint_row > 0) {
+                        if ctx.input(|i| i.key_pressed(Key::ArrowUp))
+                            && (current_constraint_row > 0)
+                        {
                             current_constraint_row -= 1;
                             self.state.clicked_constraint_index = Some(current_constraint_row);
                             // Scroll up with the selection

--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -1,6 +1,6 @@
 use egui::{
     text::{LayoutJob, TextFormat},
-    Color32, FontId, Label, NumExt, Rect, Response, RichText, ScrollArea, TextStyle, Ui, Vec2,
+    Color32, FontId, Label, NumExt, Rect, Response, RichText, ScrollArea, TextStyle, Ui, Vec2
 };
 use std::ops::Add;
 
@@ -8,7 +8,7 @@ use super::SATApp;
 
 impl SATApp {
     /// Constraint list GUI element
-    pub fn constraint_list(&mut self, ui: &mut Ui, width: f32) -> Response {
+    pub fn constraint_list(&mut self, ui: &mut Ui, ctx: &egui::Context, width: f32) -> Response {
         // Text scale magic numbers chosen based on testing through ui
         let text_scale = (width / 35.0).max(10.0);
 

--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -198,30 +198,32 @@ impl SATApp {
                     
                     let mut scroll_delta = Vec2::ZERO;
 
-                    // Actions when a constraint row is clicked with the ArrowDown button
-                    if ctx.input(|i| i.key_pressed(Key::ArrowDown))
-                        && current_constraint_row < self.state.filtered_length - 1
-                        && current_constraint_row % self.state.page_length
-                            < self.state.page_length - 1
-                        && current_constraint_row < current_page_length
-                    {
-                        current_constraint_row += 1;
-                        self.state.clicked_constraint_index = Some(current_constraint_row);
-                        // Check how far down the visible list currently and keep in view
-                        if current_constraint_row > last_item - 5 {
-                        // Scroll down with the selection
-                            scroll_delta.y -= row_height;
+                    if self.state.clicked_constraint_index.is_some() {
+                        // Actions when a constraint row is clicked with the ArrowDown button
+                        if ctx.input(|i| i.key_pressed(Key::ArrowDown))
+                            && current_constraint_row < self.state.filtered_length - 1
+                            && current_constraint_row % self.state.page_length
+                                < self.state.page_length - 1
+                            && current_constraint_row < current_page_length
+                        {
+                            current_constraint_row += 1;
+                            self.state.clicked_constraint_index = Some(current_constraint_row);
+                            // Check how far down the visible list currently and keep in view
+                            if current_constraint_row > last_item - 5 {
+                            // Scroll down with the selection
+                                scroll_delta.y -= row_height;
+                            }
                         }
-                    }
 
-                    // Actions when a constraint row is clicked with the ArrowUp button
-                    if ctx.input(|i| i.key_pressed(Key::ArrowUp)) && (current_constraint_row > 0) {
-                        current_constraint_row -= 1;
-                        self.state.clicked_constraint_index = Some(current_constraint_row);
-                        // Scroll up with the selection
-                        scroll_delta.y += row_height;
+                        // Actions when a constraint row is clicked with the ArrowUp button
+                        if ctx.input(|i| i.key_pressed(Key::ArrowUp)) && (current_constraint_row > 0) {
+                            current_constraint_row -= 1;
+                            self.state.clicked_constraint_index = Some(current_constraint_row);
+                            // Scroll up with the selection
+                            scroll_delta.y += row_height;
+                        }
+                        ui.scroll_with_delta(scroll_delta);
                     }
-                    ui.scroll_with_delta(scroll_delta);
                 });
         })
     }

--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -180,19 +180,35 @@ impl SATApp {
                         }
                     }
 
-                    let current_constraint_row: usize =
+                    // Index of the row that has been clicked on the particular page, between 0 and page length minus 1
+                    let mut current_constraint_row: usize =
                         self.state.clicked_constraint_index.unwrap_or(0);
+
+                    // Number of the rows on the current page, which might be less on the last page than on other pages
+                    let mut current_page_length: usize = self.state.page_length;
+
+                    // Check number of the rows on the last page
+                    if self.state.page_number + 1 == self.state.page_count {
+                        if self.state.filtered_length % self.state.page_length != 0 {
+                            current_page_length = self.state.filtered_length
+                                - ((self.state.page_count as usize - 1) * self.state.page_length)
+                                - 1;
+                        }
+                    }
+
                     if ctx.input(|i| i.key_pressed(Key::ArrowDown))
-                        && (current_constraint_row < self.state.filtered_length - 1)
+                        && current_constraint_row < self.state.filtered_length - 1
                         && current_constraint_row % self.state.page_length
                             < self.state.page_length - 1
+                        && current_constraint_row < current_page_length
                     {
-                        self.state.clicked_constraint_index = Some(current_constraint_row + 1);
-                        println!("Go to line number {}", current_constraint_row + 1 + 1)
+                        current_constraint_row += 1;
+                        self.state.clicked_constraint_index = Some(current_constraint_row);
                     }
+
                     if ctx.input(|i| i.key_pressed(Key::ArrowUp)) && (current_constraint_row > 0) {
-                        self.state.clicked_constraint_index = Some(current_constraint_row - 1);
-                        println!("Go to line number {}", current_constraint_row - 1 + 1)
+                        current_constraint_row -= 1;
+                        self.state.clicked_constraint_index = Some(current_constraint_row);
                     }
                 });
         })

--- a/src/gui/constraint_list.rs
+++ b/src/gui/constraint_list.rs
@@ -188,14 +188,15 @@ impl SATApp {
                     let mut current_page_length: usize = self.state.page_length;
 
                     // Check number of the rows on the last page
-                    if self.state.page_number + 1 == self.state.page_count {
-                        if self.state.filtered_length % self.state.page_length != 0 {
-                            current_page_length = self.state.filtered_length
-                                - ((self.state.page_count as usize - 1) * self.state.page_length)
-                                - 1;
-                        }
+                    if self.state.page_number + 1 == self.state.page_count
+                        && self.state.filtered_length % self.state.page_length != 0
+                    {
+                        current_page_length = self.state.filtered_length
+                            - ((self.state.page_count as usize - 1) * self.state.page_length)
+                            - 1;
                     }
 
+                    // Actions when a constraint row is clicked with the ArrowDown button
                     if ctx.input(|i| i.key_pressed(Key::ArrowDown))
                         && current_constraint_row < self.state.filtered_length - 1
                         && current_constraint_row % self.state.page_length
@@ -206,6 +207,7 @@ impl SATApp {
                         self.state.clicked_constraint_index = Some(current_constraint_row);
                     }
 
+                    // Actions when a constraint row is clicked with the ArrowUp button
                     if ctx.input(|i| i.key_pressed(Key::ArrowUp)) && (current_constraint_row > 0) {
                         current_constraint_row -= 1;
                         self.state.clicked_constraint_index = Some(current_constraint_row);

--- a/src/gui/controls.rs
+++ b/src/gui/controls.rs
@@ -226,7 +226,9 @@ impl SATApp {
 
     fn page_buttons(&mut self, ui: &mut Ui, text_scale: f32, ctx: &egui::Context) -> egui::InnerResponse<()> {
         ui.horizontal(|ui| {
-            if ui.button(RichText::new("<<").size(text_scale)).clicked()
+            if (ui.button(RichText::new("<<").size(text_scale)).clicked()
+                ||
+                ctx.input(|i| i.modifiers.shift && i.key_pressed(Key::ArrowLeft)))
                 && self.state.page_number > 0
             {
                 self.state.set_page_number(0);
@@ -234,7 +236,9 @@ impl SATApp {
                     create_tuples_from_constraints(self.state.get_filtered());
             }
 
-            if ui.button(RichText::new("<").size(text_scale)).clicked()
+            if (ui.button(RichText::new(">>").size(text_scale)).clicked()
+                ||
+                ctx.input(|i| i.modifiers.shift && i.key_pressed(Key::ArrowRight)))
                 && self.state.page_number > 0
             {
                 self.state.set_page_number(self.state.page_number - 1);

--- a/src/gui/controls.rs
+++ b/src/gui/controls.rs
@@ -24,8 +24,11 @@ impl SATApp {
 
                 self.page_length_input(ui, text_scale, ctx);
                 ui.end_row();
+
+                self.page_buttons(ui, text_scale, ctx);
+                ui.end_row();
             });
-        self.page_buttons(ui, text_scale, ctx).response
+        self.exit_button(ui, text_scale, ctx).response
     }
 
     fn buttons(
@@ -289,6 +292,21 @@ impl SATApp {
                 &mut self.state.show_solved_sudoku,
                 RichText::new("Show solved sudoku").size(text_scale),
             );
+        })
+    }
+
+    fn exit_button(
+        &mut self,
+        ui: &mut Ui,
+        text_scale: f32,
+        ctx: &egui::Context,
+        ) -> egui::InnerResponse<()> {
+        ui.horizontal_wrapped(|ui| {
+            if ui.button(RichText::new("Quit").size(text_scale)).clicked()
+                || ctx.input(|i| i.key_pressed(Key::Q))
+                {
+                    self.state.quit();
+                }
         })
     }
 

--- a/src/gui/controls.rs
+++ b/src/gui/controls.rs
@@ -38,8 +38,7 @@ impl SATApp {
             if ui
                 .button(RichText::new("Open file...").size(text_scale))
                 .clicked()
-                || 
-                ctx.input(|i| i.key_pressed(Key::O))
+                || ctx.input(|i| i.key_pressed(Key::O))
             {
                 self.state.editor_active = false;
                 if let Some(file_path) = rfd::FileDialog::new()
@@ -68,8 +67,7 @@ impl SATApp {
             if ui
                 .button(RichText::new("Solve sudoku").size(text_scale))
                 .clicked()
-                ||
-                ctx.input(|i| i.key_pressed(Key::S))
+                || ctx.input(|i| i.key_pressed(Key::S))
             {
                 self.state.editor_active = false;
 
@@ -149,7 +147,12 @@ impl SATApp {
     }
 
     // Row for filtering functionality
-    fn filters(&mut self, ui: &mut Ui, text_scale: f32, ctx: &egui::Context) -> egui::InnerResponse<()> {
+    fn filters(
+        &mut self,
+        ui: &mut Ui,
+        text_scale: f32,
+        ctx: &egui::Context,
+    ) -> egui::InnerResponse<()> {
         // Row for filtering functionality
         ui.horizontal(|ui| {
             let max_length_label =
@@ -169,17 +172,14 @@ impl SATApp {
             if ui
                 .button(RichText::new("Select").size(text_scale))
                 .clicked()
-                ||
-                ctx.input(|i| i.key_pressed(Key::Enter))
+                || ctx.input(|i| i.key_pressed(Key::Enter))
             {
                 self.state.filter_by_max_length();
                 self.rendered_constraints =
                     create_tuples_from_constraints(self.state.get_filtered());
             }
-            if ui.button(RichText::new("Clear").size(text_scale))
-                .clicked()
-                ||
-                ctx.input(|i| i.key_pressed(Key::C))
+            if ui.button(RichText::new("Clear").size(text_scale)).clicked()
+                || ctx.input(|i| i.key_pressed(Key::C))
             {
                 self.state.clear_filters();
                 self.rendered_constraints =
@@ -188,7 +188,12 @@ impl SATApp {
         })
     }
 
-    fn page_length_input(&mut self, ui: &mut Ui, text_scale: f32, ctx: &egui::Context) -> egui::InnerResponse<()> {
+    fn page_length_input(
+        &mut self,
+        ui: &mut Ui,
+        text_scale: f32,
+        ctx: &egui::Context,
+    ) -> egui::InnerResponse<()> {
         ui.horizontal(|ui| {
             let font_id = TextStyle::Body.resolve(ui.style());
             let font = FontId::new(text_scale, font_id.family.clone());
@@ -208,8 +213,7 @@ impl SATApp {
             if ui
                 .button(RichText::new("Select").size(text_scale))
                 .clicked()
-                ||
-                ctx.input(|i| i.key_pressed(Key::Enter))
+                || ctx.input(|i| i.key_pressed(Key::Enter))
             {
                 if self.state.page_length_input.is_empty()
                     || self.state.page_length_input.eq_ignore_ascii_case("*")
@@ -224,11 +228,15 @@ impl SATApp {
         })
     }
 
-    fn page_buttons(&mut self, ui: &mut Ui, text_scale: f32, ctx: &egui::Context) -> egui::InnerResponse<()> {
+    fn page_buttons(
+        &mut self,
+        ui: &mut Ui,
+        text_scale: f32,
+        ctx: &egui::Context,
+    ) -> egui::InnerResponse<()> {
         ui.horizontal(|ui| {
             if (ui.button(RichText::new("<<").size(text_scale)).clicked()
-                ||
-                ctx.input(|i| i.modifiers.shift && i.key_pressed(Key::ArrowLeft)))
+                || ctx.input(|i| i.modifiers.shift && i.key_pressed(Key::ArrowLeft)))
                 && self.state.page_number > 0
             {
                 self.state.set_page_number(0);
@@ -237,8 +245,7 @@ impl SATApp {
             }
 
             if (ui.button(RichText::new(">>").size(text_scale)).clicked()
-                ||
-                ctx.input(|i| i.modifiers.shift && i.key_pressed(Key::ArrowRight)))
+                || ctx.input(|i| i.modifiers.shift && i.key_pressed(Key::ArrowRight)))
                 && self.state.page_number > 0
             {
                 self.state.set_page_number(self.state.page_number - 1);
@@ -259,8 +266,7 @@ impl SATApp {
             );
 
             if (ui.button(RichText::new("<").size(text_scale)).clicked()
-                ||
-                ctx.input(|i| i.key_pressed(Key::ArrowLeft)))
+                || ctx.input(|i| i.key_pressed(Key::ArrowLeft)))
                 && self.state.page_count > 0
                 && self.state.page_number < self.state.page_count - 1
             {
@@ -270,8 +276,7 @@ impl SATApp {
             }
 
             if (ui.button(RichText::new(">").size(text_scale)).clicked()
-                ||
-                ctx.input(|i| i.key_pressed(Key::ArrowRight)))
+                || ctx.input(|i| i.key_pressed(Key::ArrowRight)))
                 && self.state.page_count > 0
                 && self.state.page_number < self.state.page_count - 1
             {

--- a/src/gui/controls.rs
+++ b/src/gui/controls.rs
@@ -247,8 +247,8 @@ impl SATApp {
                     create_tuples_from_constraints(self.state.get_filtered());
             }
 
-            if (ui.button(RichText::new(">>").size(text_scale)).clicked()
-                || ctx.input(|i| i.modifiers.shift && i.key_pressed(Key::ArrowRight)))
+            if (ui.button(RichText::new("<").size(text_scale)).clicked()
+                || ctx.input(|i| i.key_pressed(Key::ArrowLeft)))
                 && self.state.page_number > 0
             {
                 self.state.set_page_number(self.state.page_number - 1);
@@ -268,8 +268,8 @@ impl SATApp {
                 .wrap(false),
             );
 
-            if (ui.button(RichText::new("<").size(text_scale)).clicked()
-                || ctx.input(|i| i.key_pressed(Key::ArrowLeft)))
+            if (ui.button(RichText::new(">").size(text_scale)).clicked()
+                || ctx.input(|i| i.key_pressed(Key::ArrowRight)))
                 && self.state.page_count > 0
                 && self.state.page_number < self.state.page_count - 1
             {
@@ -278,8 +278,8 @@ impl SATApp {
                     create_tuples_from_constraints(self.state.get_filtered());
             }
 
-            if (ui.button(RichText::new(">").size(text_scale)).clicked()
-                || ctx.input(|i| i.key_pressed(Key::ArrowRight)))
+            if (ui.button(RichText::new(">>").size(text_scale)).clicked()
+                || ctx.input(|i| i.modifiers.shift && i.key_pressed(Key::ArrowRight)))
                 && self.state.page_count > 0
                 && self.state.page_number < self.state.page_count - 1
             {
@@ -300,13 +300,13 @@ impl SATApp {
         ui: &mut Ui,
         text_scale: f32,
         ctx: &egui::Context,
-        ) -> egui::InnerResponse<()> {
+    ) -> egui::InnerResponse<()> {
         ui.horizontal_wrapped(|ui| {
             if ui.button(RichText::new("Quit").size(text_scale)).clicked()
                 || ctx.input(|i| i.key_pressed(Key::Q))
-                {
-                    self.state.quit();
-                }
+            {
+                self.state.quit();
+            }
         })
     }
 

--- a/src/gui/controls.rs
+++ b/src/gui/controls.rs
@@ -1,5 +1,5 @@
 use cadical::Solver;
-use egui::{FontId, Key, Label, Response, RichText, TextStyle, Ui};
+use egui::{FontId, InputState, Modifiers, Key, Label, Response, RichText, TextStyle, Ui};
 
 use crate::{cnf_converter::create_tuples_from_constraints, solve_sudoku, GenericError};
 
@@ -38,6 +38,8 @@ impl SATApp {
             if ui
                 .button(RichText::new("Open file...").size(text_scale))
                 .clicked()
+                || 
+                ctx.input(|i| i.key_pressed(Key::O))
             {
                 self.state.editor_active = false;
                 if let Some(file_path) = rfd::FileDialog::new()


### PR DESCRIPTION
Key input with the merge conflicts solved

From [original PR](https://github.com/SAT-STEP/SAT-STEP/pull/44#issue-1976018193)

Added keyboard input controls to use the app as follows:

    arrows to scroll constraint rows & pages
    key input
    O - Open file
    S - Solve sudoku
    Q - Quit the app
    enter button
    max constraint length __
    number of rows... __

Are there any required functions still missing? Or is there something that is not working as supposed?
Thanks for review & testing!
