### PR TITLE
Move tests from lib.rs to tests.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@ mod error;
 mod filtering;
 pub mod gui;
 
+#[cfg(test)]
+mod tests;
+
 use std::{cell::RefCell, fs, num::ParseIntError, path::Path, rc::Rc};
 
 use cadical::Solver;
@@ -161,72 +164,5 @@ pub fn parse_numeric_input(input: &str) -> Option<i32> {
             Some(parsed)
         }
         Err(_err) => None,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::path::Path;
-
-    #[test]
-    fn test_get_sudoku() {
-        let test_file: String = "./data/sample_sudoku.txt".to_string();
-        let test_getting_sudoku = get_sudoku(test_file);
-
-        assert!(test_getting_sudoku.is_ok());
-    }
-
-    #[test]
-    fn test_get_no_sudoku() {
-        let test_file: String = "./data/foo_sudoku.txt".to_string();
-        let test_file_exists: bool = Path::new("./data/foo_sudoku.txt").exists();
-        let test_getting_sudoku = get_sudoku(test_file);
-
-        assert_eq!(test_file_exists, false);
-        assert!(test_getting_sudoku.is_err());
-    }
-
-    #[test]
-    fn test_get_wrong_filetype() {
-        let test_file: String = "./data/foo.exe".to_string();
-        let file_exists: bool = Path::new("./data/foo.exe").exists();
-        let assumed_error_message = "Invalid filetype!".to_string();
-        let test_result = get_sudoku(test_file);
-
-        assert_eq!(file_exists, false);
-        assert_eq!(test_result.err().unwrap().msg, assumed_error_message);
-    }
-
-    #[test]
-    fn test_write_sudoku() {
-        let test_text: String = "00000000".to_string();
-        let test_path: &Path = Path::new("./data/test_sudoku.txt");
-        let written = write_sudoku(test_text, &test_path);
-        let read_to_text = fs::read_to_string(test_path).unwrap();
-
-        assert!(written.is_ok());
-        assert_eq!(read_to_text, "00000000".to_string());
-    }
-
-    #[test]
-    fn test_write_no_sudoku() {
-        let test_text: String = "".to_string();
-        let test_path: &Path = Path::new("");
-        let written = write_sudoku(test_text, &test_path);
-
-        assert!(written.is_err());
-    }
-
-    #[test]
-    fn test_write_no_valid_path() {
-        let test_text2: String = "".to_string();
-        let test_path2: &Path = Path::new("./foo/foo.txt");
-        let path_exists: bool = test_path2.exists();
-        let assumed_error_message = "Saving the file failed".to_string();
-        let test_result = write_sudoku(test_text2, &test_path2);
-
-        assert_eq!(path_exists, false);
-        assert_eq!(test_result.err().unwrap().msg, assumed_error_message);
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::path::Path;
 
 #[test]
 fn test_get_sudoku() {
@@ -212,4 +213,57 @@ fn test_trail() {
     assert_eq!(trail.len(), 0);
     assert_eq!(trail.is_empty(), true);
     assert_eq!(trail.conflict_literals.borrow().len(), 0);
+}
+
+#[test]
+fn test_get_no_sudoku() {
+    let test_file: String = "./data/foo_sudoku.txt".to_string();
+    let test_file_exists: bool = Path::new("./data/foo_sudoku.txt").exists();
+    let test_getting_sudoku = get_sudoku(test_file);
+
+    assert_eq!(test_file_exists, false);
+    assert!(test_getting_sudoku.is_err());
+}
+
+#[test]
+fn test_get_wrong_filetype() {
+    let test_file: String = "./data/foo.exe".to_string();
+    let file_exists: bool = Path::new("./data/foo.exe").exists();
+    let assumed_error_message = "Invalid filetype!".to_string();
+    let test_result = get_sudoku(test_file);
+
+    assert_eq!(file_exists, false);
+    assert_eq!(test_result.err().unwrap().msg, assumed_error_message);
+}
+
+#[test]
+fn test_write_sudoku() {
+    let test_text: String = "00000000".to_string();
+    let test_path: &Path = Path::new("./data/test_sudoku.txt");
+    let written = write_sudoku(test_text, &test_path);
+    let read_to_text = fs::read_to_string(test_path).unwrap();
+
+    assert!(written.is_ok());
+    assert_eq!(read_to_text, "00000000".to_string());
+}
+
+#[test]
+fn test_write_no_sudoku() {
+    let test_text: String = "".to_string();
+    let test_path: &Path = Path::new("");
+    let written = write_sudoku(test_text, &test_path);
+
+    assert!(written.is_err());
+}
+
+#[test]
+fn test_write_no_valid_path() {
+    let test_text2: String = "".to_string();
+    let test_path2: &Path = Path::new("./foo/foo.txt");
+    let path_exists: bool = test_path2.exists();
+    let assumed_error_message = "Saving the file failed".to_string();
+    let test_result = write_sudoku(test_text2, &test_path2);
+
+    assert_eq!(path_exists, false);
+    assert_eq!(test_result.err().unwrap().msg, assumed_error_message);
 }


### PR DESCRIPTION
In a previous commit, some tests were added to `lib.rs`. This broke the tests in `tests.rs`, because they used the same module name. This commit moves the tests to where they should be