### PR TITLE
Improve little symbols

### DIFF
--- a/src/gui/sudoku_cell.rs
+++ b/src/gui/sudoku_cell.rs
@@ -5,8 +5,8 @@ use egui::{
 };
 
 const BIG_NUMBER_MULTIPLIER: f32 = 0.6; // Of cell size
-const LITTLE_NUMBER_MULTIPLIER: f32 = 0.2; // Of cell size
-const EMPTY_ROW_MULTIPLIER: f32 = LITTLE_NUMBER_MULTIPLIER * 0.6; // Of cell size
+const LITTLE_NUMBER_MULTIPLIER: f32 = 0.225; // Of cell size
+const EMPTY_ROW_MULTIPLIER: f32 = LITTLE_NUMBER_MULTIPLIER * 0.3; // Of cell size
 
 /// Struct representing a cell in the sudoku sudoku_grid
 #[derive(Clone)]
@@ -82,6 +82,7 @@ impl SudokuCell {
 
             self.prepare_little_symbols(&mut text_job, size);
 
+
             let galley = ui.fonts(|f| f.layout_job(text_job));
 
             // TODO: Fix this for binary encoding
@@ -95,10 +96,15 @@ impl SudokuCell {
     // TODO: Improve this? This is good enough for now, but was done quickly to get a PR made
     /// Append fields `little_numbers` and `eq_symbols` into a LayoutJob that is ready to draw
     fn prepare_little_symbols(&self, text_job: &mut LayoutJob, size: f32) {
-        let mut littles = self.little_numbers.clone();
+        let mut nums: Vec<String> = self.little_numbers.clone().iter().map(|x| x.to_string()).collect();
+        let mut littles = self.eq_symbols.clone();
 
-        littles.sort();
-        littles.dedup();
+        //eqs.sort();
+        nums.sort();
+        nums.dedup();
+
+        littles.append(&mut nums);
+
 
         let font_id =
             egui::FontId::new(size * LITTLE_NUMBER_MULTIPLIER, egui::FontFamily::Monospace);
@@ -108,7 +114,7 @@ impl SudokuCell {
         for (i, val) in littles.iter().enumerate() {
             if i % 3 == 0 && i > 0 {
                 text_job.append(
-                    "\n\n",
+                    "\n",
                     0.0,
                     TextFormat {
                         font_id: space_font_id.clone(),
@@ -116,7 +122,7 @@ impl SudokuCell {
                     },
                 );
             }
-            let text = if *val > 0 {
+            let text = if val.len() == 1 {
                 format!(" {}", *val)
             } else {
                 (*val).to_string()
@@ -126,7 +132,9 @@ impl SudokuCell {
                 0.0,
                 TextFormat {
                     font_id: font_id.clone(),
-                    color: if *val > 0 {
+                    color: if val.parse::<i32>().is_err() {
+                        Color32::YELLOW
+                    } else if val.parse::<i32>().unwrap() > 0 {
                         Color32::BLUE
                     } else {
                         Color32::RED

--- a/src/gui/sudoku_cell.rs
+++ b/src/gui/sudoku_cell.rs
@@ -100,7 +100,6 @@ impl SudokuCell {
             .collect();
         let mut littles = self.eq_symbols.clone();
 
-        //eqs.sort();
         nums.sort();
         nums.dedup();
 

--- a/src/gui/sudoku_cell.rs
+++ b/src/gui/sudoku_cell.rs
@@ -82,21 +82,22 @@ impl SudokuCell {
 
             self.prepare_little_symbols(&mut text_job, size);
 
-
             let galley = ui.fonts(|f| f.layout_job(text_job));
 
-            // TODO: Fix this for binary encoding
             ui.painter().galley(self.top_left, galley);
         }
 
         selection_changed
     }
 
-    // TODO: Fix this for binary encoding
-    // TODO: Improve this? This is good enough for now, but was done quickly to get a PR made
     /// Append fields `little_numbers` and `eq_symbols` into a LayoutJob that is ready to draw
     fn prepare_little_symbols(&self, text_job: &mut LayoutJob, size: f32) {
-        let mut nums: Vec<String> = self.little_numbers.clone().iter().map(|x| x.to_string()).collect();
+        let mut nums: Vec<String> = self
+            .little_numbers
+            .clone()
+            .iter()
+            .map(|x| x.to_string())
+            .collect();
         let mut littles = self.eq_symbols.clone();
 
         //eqs.sort();
@@ -104,7 +105,6 @@ impl SudokuCell {
         nums.dedup();
 
         littles.append(&mut nums);
-
 
         let font_id =
             egui::FontId::new(size * LITTLE_NUMBER_MULTIPLIER, egui::FontFamily::Monospace);

--- a/src/gui/sudoku_grid.rs
+++ b/src/gui/sudoku_grid.rs
@@ -231,11 +231,8 @@ impl SATApp {
                             ..
                         } => {
                             if !self.state.show_trail {
-                                let mut symbol = String::from("?");
-                                if eq_symbols.len() > 0 {
-                                    symbol = eq_symbols.next().unwrap();
-                                }
-                                
+                                let symbol = eq_symbols.next().unwrap_or_else(|| "?".to_string());
+                        
                                 self.sudoku[row as usize - 1][col as usize - 1]
                                     .eq_symbols
                                     .push(symbol.clone());
@@ -292,10 +289,8 @@ impl SATApp {
                         col2,
                         ..
                     } => {
-                        let mut symbol = String::from("?");
-                        if eq_symbols.len() > 0 {
-                            symbol = eq_symbols.next().unwrap();
-                        }
+                        let symbol = eq_symbols.next().unwrap_or_else(|| "?".to_string());
+
                         self.sudoku[row as usize - 1][col as usize - 1]
                             .eq_symbols
                             .push(symbol.clone());

--- a/src/gui/sudoku_grid.rs
+++ b/src/gui/sudoku_grid.rs
@@ -242,6 +242,8 @@ impl SATApp {
                                 self.sudoku[row2 as usize - 1][col2 as usize - 1]
                                     .eq_symbols
                                     .push(symbol);
+                                self.sudoku[row as usize - 1][col as usize - 1].draw_big_number = false;
+                                self.sudoku[row2 as usize - 1][col2 as usize - 1].draw_big_number = false;
                             }
                         }
                     }

--- a/src/gui/sudoku_grid.rs
+++ b/src/gui/sudoku_grid.rs
@@ -204,7 +204,8 @@ impl SATApp {
                         .collect()
                 };
 
-                let mut eq_symbols = (b'A'..=b'Z').chain(b'a'..=b'z')
+                let mut eq_symbols = (b'A'..=b'Z')
+                    .chain(b'a'..=b'z')
                     .map(|c| String::from_utf8(vec![c]).unwrap())
                     .collect::<Vec<String>>()
                     .into_iter();
@@ -232,15 +233,17 @@ impl SATApp {
                         } => {
                             if !self.state.show_trail {
                                 let symbol = eq_symbols.next().unwrap_or_else(|| "?".to_string());
-                        
+
                                 self.sudoku[row as usize - 1][col as usize - 1]
                                     .eq_symbols
                                     .push(symbol.clone());
                                 self.sudoku[row2 as usize - 1][col2 as usize - 1]
                                     .eq_symbols
                                     .push(symbol);
-                                self.sudoku[row as usize - 1][col as usize - 1].draw_big_number = false;
-                                self.sudoku[row2 as usize - 1][col2 as usize - 1].draw_big_number = false;
+                                self.sudoku[row as usize - 1][col as usize - 1].draw_big_number =
+                                    false;
+                                self.sudoku[row2 as usize - 1][col2 as usize - 1].draw_big_number =
+                                    false;
                             }
                         }
                     }
@@ -263,7 +266,8 @@ impl SATApp {
                 variables = self.state.little_number_constraints.clone();
             }
 
-            let mut eq_symbols = (b'A'..=b'Z').chain(b'a'..=b'z')
+            let mut eq_symbols = (b'A'..=b'Z')
+                .chain(b'a'..=b'z')
                 .map(|c| String::from_utf8(vec![c]).unwrap())
                 .collect::<Vec<String>>()
                 .into_iter();

--- a/src/gui/sudoku_grid.rs
+++ b/src/gui/sudoku_grid.rs
@@ -204,10 +204,13 @@ impl SATApp {
                         .collect()
                 };
 
-                let mut eq_symbols = (b'A'..=b'Z')
-                    .map(|c| String::from_utf8(vec![c]).unwrap())
-                    .collect::<Vec<String>>()
-                    .into_iter();
+                // let mut eq_symbols = (b'a'..=b'z').chain(b'A'..=b'Z')
+                //     .map(|c| String::from_utf8(vec![c]).unwrap())
+                //     .collect::<Vec<String>>()
+                //     .into_iter();
+
+                let eq_symbols2 = (1..=10000).collect::<Vec<i32>>();
+                let mut eq_symbols = eq_symbols2.iter().map(|x| x.to_string()).into_iter();
 
                 for variable in variables {
                     match variable {

--- a/src/gui/sudoku_grid.rs
+++ b/src/gui/sudoku_grid.rs
@@ -204,14 +204,6 @@ impl SATApp {
                         .collect()
                 };
 
-                // let mut eq_symbols = (b'a'..=b'z').chain(b'A'..=b'Z')
-                //     .map(|c| String::from_utf8(vec![c]).unwrap())
-                //     .collect::<Vec<String>>()
-                //     .into_iter();
-
-                let eq_symbols2 = (1..=10000).collect::<Vec<i32>>();
-                let mut eq_symbols = eq_symbols2.iter().map(|x| x.to_string()).into_iter();
-
                 for variable in variables {
                     match variable {
                         CnfVariable::Bit { row, col, .. } => {
@@ -226,20 +218,8 @@ impl SATApp {
                                 .push(value);
                             self.sudoku[row as usize - 1][col as usize - 1].draw_big_number = false;
                         }
-                        CnfVariable::Equality {
-                            row,
-                            col,
-                            row2,
-                            col2,
-                            ..
-                        } => {
-                            let symbol = eq_symbols.next().unwrap();
-                            self.sudoku[row as usize - 1][col as usize - 1]
-                                .eq_symbols
-                                .push(symbol.clone());
-                            self.sudoku[row2 as usize - 1][col2 as usize - 1]
-                                .eq_symbols
-                                .push(symbol);
+                        CnfVariable::Equality {..} => {
+                            continue;
                         }
                     }
                 }

--- a/src/gui/sudoku_grid.rs
+++ b/src/gui/sudoku_grid.rs
@@ -204,6 +204,11 @@ impl SATApp {
                         .collect()
                 };
 
+                let mut eq_symbols = (b'A'..=b'Z').chain(b'a'..=b'z')
+                    .map(|c| String::from_utf8(vec![c]).unwrap())
+                    .collect::<Vec<String>>()
+                    .into_iter();
+
                 for variable in variables {
                     match variable {
                         CnfVariable::Bit { row, col, .. } => {
@@ -218,8 +223,26 @@ impl SATApp {
                                 .push(value);
                             self.sudoku[row as usize - 1][col as usize - 1].draw_big_number = false;
                         }
-                        CnfVariable::Equality {..} => {
-                            continue;
+                        CnfVariable::Equality {
+                            row,
+                            col,
+                            row2,
+                            col2,
+                            ..
+                        } => {
+                            if !self.state.show_trail {
+                                let mut symbol = String::from("?");
+                                if eq_symbols.len() > 0 {
+                                    symbol = eq_symbols.next().unwrap();
+                                }
+                                
+                                self.sudoku[row as usize - 1][col as usize - 1]
+                                    .eq_symbols
+                                    .push(symbol.clone());
+                                self.sudoku[row2 as usize - 1][col2 as usize - 1]
+                                    .eq_symbols
+                                    .push(symbol);
+                            }
                         }
                     }
                 }
@@ -241,7 +264,7 @@ impl SATApp {
                 variables = self.state.little_number_constraints.clone();
             }
 
-            let mut eq_symbols = (b'A'..=b'Z')
+            let mut eq_symbols = (b'A'..=b'Z').chain(b'a'..=b'z')
                 .map(|c| String::from_utf8(vec![c]).unwrap())
                 .collect::<Vec<String>>()
                 .into_iter();
@@ -267,7 +290,10 @@ impl SATApp {
                         col2,
                         ..
                     } => {
-                        let symbol = eq_symbols.next().unwrap();
+                        let mut symbol = String::from("?");
+                        if eq_symbols.len() > 0 {
+                            symbol = eq_symbols.next().unwrap();
+                        }
                         self.sudoku[row as usize - 1][col as usize - 1]
                             .eq_symbols
                             .push(symbol.clone());


### PR DESCRIPTION
This improves how little symbols are drawn in the sudoku grid. Equality constraint symbols are also drawn, in yellow, and one sudoku cell can hold 12 values instead of the previous max. of 9. 