### PR TITLE
Cell map for binary cnf

### DIFF
--- a/src/filtering.rs
+++ b/src/filtering.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::{app_state::EncodingType, cnf::decimal_encoding::identifier_to_tuple, ConstraintList};
+use crate::{app_state::EncodingType, cnf::CnfVariable, ConstraintList};
 
 pub struct ListFilter {
     constraints: ConstraintList,
@@ -44,8 +44,8 @@ impl ListFilter {
         self.create_cell_map(encoding);
     }
 
-    // TODO: Fix for binary encoding
-    fn create_cell_map(&mut self, _encoding: &EncodingType) {
+    /// Create map for which constraints apply to each cell
+    fn create_cell_map(&mut self, encoding: &EncodingType) {
         for row in 1..=9 {
             for col in 1..=9 {
                 self.cell_constraints.insert((row, col), HashSet::new());
@@ -53,9 +53,32 @@ impl ListFilter {
         }
         for (index, list) in self.constraints.borrow().iter().enumerate() {
             for identifier in list {
-                let (row, col, _) = identifier_to_tuple(*identifier);
-                if let Some(cell_set) = self.cell_constraints.get_mut(&(row, col)) {
-                    cell_set.insert(index);
+                let var = CnfVariable::from_cnf(*identifier, encoding);
+                match var {
+                    CnfVariable::Bit { row, col, .. } => {
+                        if let Some(cell_set) = self.cell_constraints.get_mut(&(row, col)) {
+                            cell_set.insert(index);
+                        }
+                    }
+                    CnfVariable::Decimal { row, col, .. } => {
+                        if let Some(cell_set) = self.cell_constraints.get_mut(&(row, col)) {
+                            cell_set.insert(index);
+                        }
+                    }
+                    CnfVariable::Equality {
+                        row,
+                        col,
+                        row2,
+                        col2,
+                        ..
+                    } => {
+                        if let Some(cell_set) = self.cell_constraints.get_mut(&(row, col)) {
+                            cell_set.insert(index);
+                        }
+                        if let Some(cell_set) = self.cell_constraints.get_mut(&(row2, col2)) {
+                            cell_set.insert(index);
+                        }
+                    }
                 }
             }
         }
@@ -153,7 +176,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_by_cell() {
+    fn test_filter_by_cell_decimal() {
         let constraints = ConstraintList::_new(Rc::new(RefCell::new(vec![
             vec![1; 10],
             vec![10; 3],
@@ -161,6 +184,32 @@ mod tests {
         ])));
         let mut filter: ListFilter = ListFilter::new(constraints.clone());
         filter.reinit(&EncodingType::Decimal);
+
+        filter.by_cell(1, 1);
+        let (filtered, filtered_length) = filter.get_filtered(0, 50);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered_length, 1);
+
+        filter.by_cell(1, 2);
+        let (filtered2, filtered_length2) = filter.get_filtered(0, 50);
+        assert_eq!(filtered2.len(), 2);
+        assert_eq!(filtered_length2, 2);
+
+        filter.by_cell(2, 2);
+        let (filtered3, filtered_length3) = filter.get_filtered(0, 50);
+        assert_eq!(filtered3.len(), 0);
+        assert_eq!(filtered_length3, 0);
+    }
+
+    #[test]
+    fn test_filter_by_cell_binary() {
+        let constraints = ConstraintList::_new(Rc::new(RefCell::new(vec![
+            vec![1; 10],
+            vec![5; 3],
+            vec![5; 3],
+        ])));
+        let mut filter: ListFilter = ListFilter::new(constraints.clone());
+        filter.reinit(&EncodingType::Binary);
 
         filter.by_cell(1, 1);
         let (filtered, filtered_length) = filter.get_filtered(0, 50);


### PR DESCRIPTION
[Based on another branch that should be reviewed and merged first!](https://github.com/SAT-STEP/SAT-STEP/pull/59)

Implement cell based filtering for binary encoded CNF in addition to the old decimal form.