### PR TITLE
Show decided variables in trail

### DIFF
--- a/cadical-rs/cadical/src/backtrack.cpp
+++ b/cadical-rs/cadical/src/backtrack.cpp
@@ -103,11 +103,13 @@ void Internal::backtrack (int new_level) {
       if (!v.level) LOG ("reassign %d @ 0 unit clause %d", lit, lit);
       else LOG (v.reason, "reassign %d @ %d", lit, v.level);
 #endif
+      trail_var_is_propagated[j] = v.reason != nullptr;
       trail[j] = lit;
       v.trail = j++;
       reassigned++;
     }
   }
+  trail_var_is_propagated.resize(j);
   trail.resize (j);
   LOG ("unassigned %d literals %.0f%%",
     unassigned, percent (unassigned, unassigned + reassigned));

--- a/cadical-rs/cadical/src/cadical.hpp
+++ b/cadical-rs/cadical/src/cadical.hpp
@@ -834,7 +834,7 @@ public:
   virtual void learn (int lit) = 0;
 
   // PAAVO:
-  virtual void learn_trail (unsigned long conflict_size, int* conflict_literals, unsigned long size, int* trail) = 0;
+  virtual void learn_trail (unsigned long conflict_size, int* conflict_literals, unsigned long propagated_size, int* is_propagated, unsigned long size, int* trail) = 0;
 };
 
 /*------------------------------------------------------------------------*/

--- a/cadical-rs/cadical/src/ccadical.cpp
+++ b/cadical-rs/cadical/src/ccadical.cpp
@@ -19,7 +19,7 @@ struct Wrapper : Learner, Terminator {
     int * begin_clause, * end_clause, * capacity_clause;
     void (*function) (void *, int *);
     // PAAVO:
-    void (*trail_function) (void *, unsigned long, int *, unsigned long, int *);
+    void (*trail_function) (void *, unsigned long, int *,  unsigned long, int *, unsigned long, int *);
   } learner;
 
   bool terminate () {
@@ -51,8 +51,8 @@ struct Wrapper : Learner, Terminator {
   }
 
   // PAAVO:
-  void learn_trail (unsigned long conflict_size, int* conflict_literals, unsigned long size, int* data) {
-    learner.trail_function (learner.state, conflict_size, conflict_literals, size, data);
+  void learn_trail (unsigned long conflict_size, int* conflict_literals, unsigned long propagated_size, int* is_propagated, unsigned long size, int* data) {
+    learner.trail_function (learner.state, conflict_size, conflict_literals, propagated_size, is_propagated, size, data);
   }
 
   Wrapper () : solver (new Solver ()) {
@@ -165,7 +165,7 @@ void ccadical_set_learn (CCaDiCaL * ptr,
 }
 
 // PAAVO:
-void ccadical_set_learn_trail(CCaDiCaL * ptr, void *state, void (*trail)(void * state, unsigned long conflict_size, int * conflict_literals, unsigned long size, int * trail)) {
+void ccadical_set_learn_trail(CCaDiCaL * ptr, void *state, void (*trail)(void * state, unsigned long conflict_size, int * conflict_literals, unsigned long propagated_size, int* is_propagated, unsigned long size, int * trail)) {
   Wrapper * wrapper = (Wrapper *) ptr;
   wrapper->learner.state = state;
   wrapper->learner.trail_function = trail;

--- a/cadical-rs/cadical/src/ccadical.h
+++ b/cadical-rs/cadical/src/ccadical.h
@@ -31,7 +31,7 @@ void ccadical_set_learn (CCaDiCaL *,
 
 // PAAVO:
 void ccadical_set_learn_trail (CCaDiCaL *,
-  void * state, void (*trail)(void * state, unsigned long conflict_size, int * conflict_literals, unsigned long size, int * trail));
+  void * state, void (*trail)(void * state, unsigned long conflict_size, int * conflict_literals, unsigned long propagated_size, int * is_propagated, unsigned long size, int * trail));
 /*------------------------------------------------------------------------*/
 
 // Non-IPASIR conformant 'C' functions.

--- a/cadical-rs/cadical/src/clause.cpp
+++ b/cadical-rs/cadical/src/clause.cpp
@@ -303,6 +303,7 @@ void Internal::assign_original_unit (int lit) {
   vals[-idx] = -tmp;
   assert (val (lit) > 0);
   assert (val (-lit) < 0);
+  trail_var_is_propagated.push_back(v.reason != nullptr);
   trail.push_back (lit);
   LOG ("original unit assign %d", lit);
   mark_fixed (lit);

--- a/cadical-rs/cadical/src/condition.cpp
+++ b/cadical-rs/cadical/src/condition.cpp
@@ -190,6 +190,9 @@ long Internal::condition_round (long delta) {
       const int lit = decide_phase (idx, true);
       condition_assign (lit);
       v.level = level;
+  
+      // VILI: Does not seem to be called with our App, but added just in case
+      trail_var_is_propagated.push_back(v.reason != nullptr);
       trail.push_back (lit);
 #if defined(LOGGING) || !defined(NDEBUG)
       additionally_assigned++;
@@ -820,6 +823,7 @@ long Internal::condition_round (long delta) {
   int additionally_unassigned = 0;
   while (trail.size () > initial_trail_level) {
     int lit = trail.back ();
+    trail_var_is_propagated.pop_back();
     trail.pop_back ();
     condition_unassign (lit);
     additionally_unassigned++;

--- a/cadical-rs/cadical/src/external.cpp
+++ b/cadical-rs/cadical/src/external.cpp
@@ -477,7 +477,11 @@ void External::export_learned_unit_clause (int ilit) {
   } else
     LOG ("not exporting learned unit clause");
 
-  learner->learn_trail(internal->conflict->size, internal->conflict->literals, internal->trail.size(), internal->trail.data());
+  //PAAVO:
+  learner->learn_trail(internal->conflict->size, internal->conflict->literals,
+                        internal->trail_var_is_propagated.size(),
+                        internal->trail_var_is_propagated.data(),
+                        internal->trail.size(), internal->trail.data());
 }
 
 void External::export_learned_large_clause (const vector<int> & clause) {
@@ -493,7 +497,11 @@ void External::export_learned_large_clause (const vector<int> & clause) {
     }
     learner->learn (0);
 
-    learner->learn_trail(internal->conflict->size, internal->conflict->literals, internal->trail.size(), internal->trail.data());
+    //PAAVO:
+    learner->learn_trail(internal->conflict->size, internal->conflict->literals,
+                      internal->trail_var_is_propagated.size(),
+                      internal->trail_var_is_propagated.data(),
+                      internal->trail.size(), internal->trail.data());
 
   } else
     LOG ("not exporting learned clause of size %zu", size);

--- a/cadical-rs/cadical/src/instantiate.cpp
+++ b/cadical-rs/cadical/src/instantiate.cpp
@@ -54,6 +54,7 @@ inline void Internal::inst_assign (int lit) {
   assert (!val (lit));
   vals[lit] = 1;
   vals[-lit] = -1;
+  trail_var_is_propagated.push_back(false);
   trail.push_back (lit);
 }
 

--- a/cadical-rs/cadical/src/internal.hpp
+++ b/cadical-rs/cadical/src/internal.hpp
@@ -179,6 +179,7 @@ struct Internal {
   size_t target_assigned;       // maximum assigned without conflict
   size_t no_conflict_until;     // largest trail prefix without conflict
   vector<int> trail;            // currently assigned literals
+  vector<bool> trail_var_is_propagated; // Corresponding literal in trail was propagated
   vector<int> clause;           // simplified in parsing & learning
   vector<int> assumptions;      // assumed literals
   vector<int> original;         // original added literals

--- a/cadical-rs/cadical/src/internal.hpp
+++ b/cadical-rs/cadical/src/internal.hpp
@@ -179,7 +179,7 @@ struct Internal {
   size_t target_assigned;       // maximum assigned without conflict
   size_t no_conflict_until;     // largest trail prefix without conflict
   vector<int> trail;            // currently assigned literals
-  vector<bool> trail_var_is_propagated; // Corresponding literal in trail was propagated
+  vector<int> trail_var_is_propagated; // Corresponding literal in trail was propagated
   vector<int> clause;           // simplified in parsing & learning
   vector<int> assumptions;      // assumed literals
   vector<int> original;         // original added literals

--- a/cadical-rs/cadical/src/propagate.cpp
+++ b/cadical-rs/cadical/src/propagate.cpp
@@ -76,7 +76,10 @@ inline void Internal::search_assign (int lit, Clause * reason) {
   assert (val (-lit) < 0);
   if (!searching_lucky_phases)
     phases.saved[idx] = tmp;                // phase saving during search
+
+  trail_var_is_propagated.push_back(v.reason != nullptr);
   trail.push_back (lit);
+  assert(trail_var_is_propagated.size() == trail.size() && "Unsure if this will fail (It should not). Remove assert or investigate bug if this fails.");
 #ifdef LOGGING
   if (!lit_level) LOG ("root-level unit assign %d @ 0", lit);
   else LOG (reason, "search assign %d @ %d", lit, lit_level);

--- a/cadical-rs/src/lib.rs
+++ b/cadical-rs/src/lib.rs
@@ -39,7 +39,7 @@ extern "C" {
     fn ccadical_set_learn_trail(
         ptr: *mut c_void,
         data: *mut c_void,
-        cbs: Option<extern "C" fn(*mut c_void, c_ulong, *const c_int, c_ulong, *const c_int)>,
+        cbs: Option<extern "C" fn(*mut c_void, c_ulong, *const c_int, c_ulong, *const c_int, c_ulong, *const c_int)>,
     );
     fn ccadical_status(ptr: *mut c_void) -> c_int;
     fn ccadical_vars(ptr: *mut c_void) -> c_int;
@@ -312,6 +312,8 @@ impl<C: Callbacks> Solver<C> {
         data: *mut c_void,
         conflict_size: c_ulong,
         conflict_literals: *const c_int,
+        propagated_size: c_ulong,
+        is_propagated: *const c_int,
         size: c_ulong,
         trail: *const c_int,
     ) {
@@ -319,11 +321,14 @@ impl<C: Callbacks> Solver<C> {
             unsafe { slice::from_raw_parts(conflict_literals, conflict_size as usize) };
         let conflict_literals = ManuallyDrop::new(conflict_literals);
 
+        let is_propagated = unsafe { slice::from_raw_parts(is_propagated, propagated_size as usize) };
+        let is_propagated = ManuallyDrop::new(is_propagated);
+
         let trail = unsafe { slice::from_raw_parts(trail, size as usize) };
         let trail = ManuallyDrop::new(trail);
 
         let cbs = unsafe { &mut *(data as *mut C) };
-        cbs.learn_trail(&conflict_literals, &trail);
+        cbs.learn_trail(&conflict_literals, &is_propagated, &trail);
     }
 
     /// Returns a mutable reference to the callbacks.
@@ -419,8 +424,9 @@ pub trait Callbacks {
     #[inline(always)]
     fn learn(&mut self, clause: &[i32]) {}
 
+    // PAAVO:
     #[allow(unused_variables)]
-    fn learn_trail(&mut self, conflict_literals: &[i32], trail: &[i32]) {}
+    fn learn_trail(&mut self, conflict_literals: &[i32], is_propagated: &[i32], trail: &[i32]) {}
 }
 
 /// Callbacks implementing a simple timeout.

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -274,7 +274,12 @@ impl AppState {
         self.trail_var_is_propagated = None;
     }
 
-    pub fn set_trail(&mut self, conflict_literals: Vec<CnfVariable>, trail: Vec<CnfVariable>, var_is_propagated: Vec<bool>) {
+    pub fn set_trail(
+        &mut self,
+        conflict_literals: Vec<CnfVariable>,
+        trail: Vec<CnfVariable>,
+        var_is_propagated: Vec<bool>,
+    ) {
         self.conflict_literals = Some(conflict_literals);
         self.trail = Some(trail);
         self.trail_var_is_propagated = Some(var_is_propagated);

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -99,6 +99,7 @@ pub struct AppState {
     pub show_trail: bool,
     pub editor_active: bool,
     pub highlight_fixed_literals: bool,
+    pub highlight_decided_vars: bool,
     pub show_warning: Warning,
 }
 
@@ -133,6 +134,7 @@ impl AppState {
             encoding,
             editor_active: false,
             highlight_fixed_literals: false,
+            highlight_decided_vars: false,
             show_warning: Warning::new(),
         }
     }

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -301,7 +301,7 @@ mod tests {
 
         let mut trails = Trail::new();
         for i in 0..3 {
-            trails.push(vec![i], vec![i]);
+            trails.push(vec![i], vec![i], vec![false]);
         }
 
         let mut state = AppState::new(constraints.clone(), trails);
@@ -346,7 +346,7 @@ mod tests {
 
         let mut trails = Trail::new();
         for i in 0..3 {
-            trails.push(vec![i], vec![i]);
+            trails.push(vec![i], vec![i], vec![false]);
         }
 
         let mut state = AppState::new(constraints.clone(), trails);
@@ -387,7 +387,7 @@ mod tests {
 
         let mut trails = Trail::new();
         for i in 0..3 {
-            trails.push(vec![i], vec![i]);
+            trails.push(vec![i], vec![i], vec![false]);
         }
 
         let mut state = AppState::new(constraints.clone(), trails);
@@ -438,7 +438,7 @@ mod tests {
 
         let mut trails = Trail::new();
         for i in 0..10 {
-            trails.push(vec![i], vec![i]);
+            trails.push(vec![i], vec![i], vec![false]);
         }
 
         let mut state: AppState = AppState::new(constraints, trails);
@@ -466,7 +466,7 @@ mod tests {
 
         let mut trails = Trail::new();
         for i in 0..10 {
-            trails.push(vec![i], vec![i]);
+            trails.push(vec![i], vec![i], vec![false]);
         }
 
         let mut state: AppState = AppState::new(constraints, trails);
@@ -500,7 +500,7 @@ mod tests {
         let mut trails = Trail::new();
 
         for i in 0..3 {
-            trails.push(vec![i], vec![i]);
+            trails.push(vec![i], vec![i], vec![false]);
         }
 
         let mut state = AppState::new(constraints.clone(), trails);
@@ -529,7 +529,7 @@ mod tests {
 
         let mut trails = Trail::new();
         for i in 0..3 {
-            trails.push(vec![i], vec![i]);
+            trails.push(vec![i], vec![i], vec![false]);
         }
 
         let mut state = AppState::new(constraints.clone(), trails);
@@ -561,7 +561,7 @@ mod tests {
 
         let mut trails = Trail::new();
         for i in 0..3 {
-            trails.push(vec![i], vec![i]);
+            trails.push(vec![i], vec![i], vec![false]);
         }
 
         let mut state = AppState::new(constraints.clone(), trails);
@@ -589,7 +589,7 @@ mod tests {
         let constraints = ConstraintList::_new(Rc::new(RefCell::new(vec![vec![0]; 10])));
         let mut trails = Trail::new();
         for i in 0..10 {
-            trails.push(vec![i], vec![i]);
+            trails.push(vec![i], vec![i], vec![false]);
         }
 
         let mut state = AppState::new(constraints.clone(), trails);

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -86,6 +86,7 @@ pub struct AppState {
     pub clicked_constraint_index: Option<usize>,
     pub conflict_literals: Option<Vec<CnfVariable>>,
     pub trail: Option<Vec<CnfVariable>>,
+    pub trail_var_is_propagated: Option<Vec<bool>>,
     pub page_number: i32,
     pub page_count: i32,
     pub page_length: usize,
@@ -119,6 +120,7 @@ impl AppState {
             clicked_constraint_index: None,
             conflict_literals: None,
             trail: None,
+            trail_var_is_propagated: None,
             page_number: 0,
             page_count: 0,
             page_length: 100,
@@ -267,11 +269,13 @@ impl AppState {
     pub fn clear_trail(&mut self) {
         self.conflict_literals = None;
         self.trail = None;
+        self.trail_var_is_propagated = None;
     }
 
-    pub fn set_trail(&mut self, conflict_literals: Vec<CnfVariable>, trail: Vec<CnfVariable>) {
+    pub fn set_trail(&mut self, conflict_literals: Vec<CnfVariable>, trail: Vec<CnfVariable>, var_is_propagated: Vec<bool>) {
         self.conflict_literals = Some(conflict_literals);
         self.trail = Some(trail);
+        self.trail_var_is_propagated = Some(var_is_propagated);
     }
 
     pub fn get_encoding_type(&mut self) -> &str {

--- a/src/cadical_wrapper.rs
+++ b/src/cadical_wrapper.rs
@@ -48,6 +48,10 @@ impl Callbacks for CadicalCallbackWrapper {
     // called when a new derived clause is learnt
     fn learn_trail(&mut self, conflict_literals: &[i32], is_propagated: &[i32], trail: &[i32]) {
         let is_propagated_vec: Vec<bool> = is_propagated.to_vec().iter().map(|x| *x > 0).collect();
-        self.trail.push(conflict_literals.to_vec(), trail.to_vec(), is_propagated_vec)
+        self.trail.push(
+            conflict_literals.to_vec(),
+            trail.to_vec(),
+            is_propagated_vec,
+        )
     }
 }

--- a/src/cadical_wrapper.rs
+++ b/src/cadical_wrapper.rs
@@ -46,7 +46,7 @@ impl Callbacks for CadicalCallbackWrapper {
     }
 
     // called when a new derived clause is learnt
-    fn learn_trail(&mut self, conflict_literals: &[i32], trail: &[i32]) {
+    fn learn_trail(&mut self, conflict_literals: &[i32], _is_propagated: &[i32], trail: &[i32]) {
         self.trail.push(conflict_literals.to_vec(), trail.to_vec())
     }
 }

--- a/src/cadical_wrapper.rs
+++ b/src/cadical_wrapper.rs
@@ -46,7 +46,8 @@ impl Callbacks for CadicalCallbackWrapper {
     }
 
     // called when a new derived clause is learnt
-    fn learn_trail(&mut self, conflict_literals: &[i32], _is_propagated: &[i32], trail: &[i32]) {
-        self.trail.push(conflict_literals.to_vec(), trail.to_vec())
+    fn learn_trail(&mut self, conflict_literals: &[i32], is_propagated: &[i32], trail: &[i32]) {
+        let is_propagated_vec: Vec<bool> = is_propagated.to_vec().iter().map(|x| *x > 0).collect();
+        self.trail.push(conflict_literals.to_vec(), trail.to_vec(), is_propagated_vec)
     }
 }

--- a/src/ctrl_obj.rs
+++ b/src/ctrl_obj.rs
@@ -41,7 +41,7 @@ impl ControllableObj for ConstraintList {
                         .map(|&x| CnfVariable::from_cnf(x, &state.encoding))
                         .collect();
 
-                    state.set_trail(enum_literals, enum_trail);
+                    state.set_trail(enum_literals, enum_trail, self.trail.var_is_propagated_at_index(i));
                 }
             }
             None => {
@@ -59,7 +59,7 @@ impl ControllableObj for ConstraintList {
                     .map(|&x| CnfVariable::from_cnf(x, &state.encoding))
                     .collect();
 
-                state.set_trail(enum_literals, enum_trail);
+                state.set_trail(enum_literals, enum_trail, self.trail.var_is_propagated_at_index(i));
             }
         }
     }

--- a/src/ctrl_obj.rs
+++ b/src/ctrl_obj.rs
@@ -41,7 +41,11 @@ impl ControllableObj for ConstraintList {
                         .map(|&x| CnfVariable::from_cnf(x, &state.encoding))
                         .collect();
 
-                    state.set_trail(enum_literals, enum_trail, self.trail.var_is_propagated_at_index(i));
+                    state.set_trail(
+                        enum_literals,
+                        enum_trail,
+                        self.trail.var_is_propagated_at_index(i),
+                    );
                 }
             }
             None => {
@@ -59,7 +63,11 @@ impl ControllableObj for ConstraintList {
                     .map(|&x| CnfVariable::from_cnf(x, &state.encoding))
                     .collect();
 
-                state.set_trail(enum_literals, enum_trail, self.trail.var_is_propagated_at_index(i));
+                state.set_trail(
+                    enum_literals,
+                    enum_trail,
+                    self.trail.var_is_propagated_at_index(i),
+                );
             }
         }
     }

--- a/src/filtering.rs
+++ b/src/filtering.rs
@@ -48,6 +48,7 @@ impl ListFilter {
             final_trail.push(
                 self.trails.literals_at_index(index),
                 self.trails.trail_at_index(index),
+                self.trails.var_is_propagated_at_index(index),
             );
         }
 

--- a/src/filtering.rs
+++ b/src/filtering.rs
@@ -184,7 +184,7 @@ mod tests {
 
         let mut trails = Trail::new();
         for i in 0..3 {
-            trails.push(vec![i], vec![i]);
+            trails.push(vec![i], vec![i], vec![false]);
         }
 
         let mut filter: ListFilter = ListFilter::new(constraints.clone(), trails);
@@ -220,7 +220,7 @@ mod tests {
 
         let mut trails = Trail::new();
         for i in 0..3 {
-            trails.push(vec![i], vec![i]);
+            trails.push(vec![i], vec![i], vec![false]);
         }
 
         let mut filter: ListFilter = ListFilter::new(constraints.clone(), trails);
@@ -264,7 +264,7 @@ mod tests {
 
         let mut trails = Trail::new();
         for i in 0..3 {
-            trails.push(vec![i], vec![i]);
+            trails.push(vec![i], vec![i], vec![false]);
         }
 
         let mut filter: ListFilter = ListFilter::new(constraints.clone(), trails);
@@ -302,7 +302,7 @@ mod tests {
 
         let mut trails = Trail::new();
         for i in 0..3 {
-            trails.push(vec![i], vec![i]);
+            trails.push(vec![i], vec![i], vec![false]);
         }
 
         let mut filter: ListFilter = ListFilter::new(constraints.clone(), trails);
@@ -362,7 +362,7 @@ mod tests {
 
         let mut trails = Trail::new();
         for i in 0..10 {
-            trails.push(vec![i], vec![i]);
+            trails.push(vec![i], vec![i], vec![false]);
         }
 
         let mut filter: ListFilter = ListFilter::new(constraints.clone(), trails);

--- a/src/gui/controls.rs
+++ b/src/gui/controls.rs
@@ -517,8 +517,9 @@ impl SATApp {
 
             if self.state.show_trail {
                 ui.checkbox(
-                    &mut self.state.highlight_decided_vars, 
-                    RichText::new("Highlight decided variables").size(text_scale));
+                    &mut self.state.highlight_decided_vars,
+                    RichText::new("Highlight decided variables").size(text_scale),
+                );
             }
         })
     }

--- a/src/gui/controls.rs
+++ b/src/gui/controls.rs
@@ -514,6 +514,12 @@ impl SATApp {
                 &mut self.state.highlight_fixed_literals,
                 RichText::new("Highlight fixed literals").size(text_scale),
             );
+
+            if self.state.show_trail {
+                ui.checkbox(
+                    &mut self.state.highlight_decided_vars, 
+                    RichText::new("Highlight decided variables").size(text_scale));
+            }
         })
     }
     fn warning_triangle(&mut self, ui: &mut Ui, text_scale: f32) -> egui::InnerResponse<()> {

--- a/src/gui/sudoku_cell.rs
+++ b/src/gui/sudoku_cell.rs
@@ -22,8 +22,10 @@ pub struct SudokuCell {
     pub clue: bool,            // Should the cell be darkened (is it a clue)
     pub part_of_conflict: bool, // Should the cell have highlighted borders
     pub fixed: bool, // Is the value of the cell set by fixed literals (used for highlighting)
-    pub eq_symbols: Vec<(String, CnfVariable, bool)>,
-    pub little_numbers: Vec<(i32, bool)>, // Bool tells us if the variable should be underlined (such as if it is part of the conflict)
+    pub eq_symbols: Vec<(String, CnfVariable, bool)>, // Bool tells if symbol should be underlined (the variable is satisfied)
+    // 1. bool tells us if the variable should be underlined (such as if it is part of the conflict)
+    // 2. bool tells if the variable should have background (it is decided, not propagated)
+    pub little_numbers: Vec<(i32, bool, bool)>, 
     pub top_left: Pos2,
     pub bottom_right: Pos2,
 }
@@ -138,6 +140,13 @@ impl SudokuCell {
             .map(|x| if x.1 { x.0.to_string() } else { String::new() })
             .collect();
 
+        let backgrounded: Vec<String> = self
+            .little_numbers
+            .clone()
+            .iter()
+            .map(|x| if x.2 { x.0.to_string() } else { String::new() })
+            .collect();
+
         underlined.extend(self.eq_symbols.iter().map(|tuple| {
             if tuple.2 {
                 tuple.0.clone()
@@ -214,6 +223,7 @@ impl SudokuCell {
                         Color32::RED
                     },
                     underline: stroke,
+                    background: if backgrounded.contains(val) { Color32::from_rgb(255, 214, 171) } else {Color32::TRANSPARENT},
                     ..Default::default()
                 },
             );

--- a/src/gui/sudoku_cell.rs
+++ b/src/gui/sudoku_cell.rs
@@ -200,9 +200,9 @@ impl SudokuCell {
                     size * UNDERLINE_MULTIPLIER,
                     if let Ok(val_i32) = val.parse::<i32>() {
                         if val_i32 > 0 {
-                            Color32::BLUE
+                            Color32::DARK_BLUE
                         } else {
-                            Color32::RED
+                            Color32::DARK_RED
                         }
                     } else {
                         Color32::YELLOW
@@ -218,9 +218,9 @@ impl SudokuCell {
                     color: if val.parse::<i32>().is_err() {
                         Color32::YELLOW
                     } else if val.parse::<i32>().unwrap() > 0 {
-                        Color32::BLUE
+                        Color32::DARK_BLUE
                     } else {
-                        Color32::RED
+                        Color32::DARK_RED
                     },
                     underline: stroke,
                     background: if backgrounded.contains(val) { Color32::from_rgb(255, 214, 171) } else {Color32::TRANSPARENT},

--- a/src/gui/sudoku_cell.rs
+++ b/src/gui/sudoku_cell.rs
@@ -25,7 +25,7 @@ pub struct SudokuCell {
     pub eq_symbols: Vec<(String, CnfVariable, bool)>, // Bool tells if symbol should be underlined (the variable is satisfied)
     // 1. bool tells us if the variable should be underlined (such as if it is part of the conflict)
     // 2. bool tells if the variable should have background (it is decided, not propagated)
-    pub little_numbers: Vec<(i32, bool, bool)>, 
+    pub little_numbers: Vec<(i32, bool, bool)>,
     pub top_left: Pos2,
     pub bottom_right: Pos2,
 }
@@ -223,7 +223,11 @@ impl SudokuCell {
                         Color32::DARK_RED
                     },
                     underline: stroke,
-                    background: if backgrounded.contains(val) { Color32::from_gray(220) } else {Color32::TRANSPARENT},
+                    background: if backgrounded.contains(val) {
+                        Color32::from_gray(220)
+                    } else {
+                        Color32::TRANSPARENT
+                    },
                     ..Default::default()
                 },
             );

--- a/src/gui/sudoku_cell.rs
+++ b/src/gui/sudoku_cell.rs
@@ -205,7 +205,7 @@ impl SudokuCell {
                             Color32::DARK_RED
                         }
                     } else {
-                        Color32::YELLOW
+                        Color32::DARK_GREEN
                     },
                 );
             }
@@ -216,14 +216,14 @@ impl SudokuCell {
                 TextFormat {
                     font_id: font_id.clone(),
                     color: if val.parse::<i32>().is_err() {
-                        Color32::YELLOW
+                        Color32::DARK_GREEN
                     } else if val.parse::<i32>().unwrap() > 0 {
                         Color32::DARK_BLUE
                     } else {
                         Color32::DARK_RED
                     },
                     underline: stroke,
-                    background: if backgrounded.contains(val) { Color32::from_rgb(255, 214, 171) } else {Color32::TRANSPARENT},
+                    background: if backgrounded.contains(val) { Color32::from_gray(220) } else {Color32::TRANSPARENT},
                     ..Default::default()
                 },
             );

--- a/src/gui/sudoku_grid.rs
+++ b/src/gui/sudoku_grid.rs
@@ -207,10 +207,14 @@ impl SATApp {
                 CnfVariable::Decimal { row, col, value } => {
                     let cell = &mut self.sudoku[row as usize - 1][col as usize - 1];
 
-                    cell.little_numbers.push((value, {
-                        value == cell.value.unwrap_or(0)
-                            || (value < 0 && value != -cell.value.unwrap_or(0))
-                    }, false));
+                    cell.little_numbers.push((
+                        value,
+                        {
+                            value == cell.value.unwrap_or(0)
+                                || (value < 0 && value != -cell.value.unwrap_or(0))
+                        },
+                        false,
+                    ));
 
                     cell.draw_big_number = false;
                 }
@@ -286,12 +290,17 @@ impl SATApp {
             if let Some(_conflict_index) = self.state.clicked_constraint_index {
                 let variables = self.state.trail.clone().unwrap();
 
-                for (i,variable) in variables.into_iter().enumerate() {
+                for (i, variable) in variables.into_iter().enumerate() {
                     if let CnfVariable::Decimal { row, col, value } = variable {
                         let cell = &mut self.sudoku[row as usize - 1][col as usize - 1];
 
                         cell.draw_big_number = false;
-                        cell.little_numbers.push((value, false, self.state.highlight_decided_vars && !self.state.trail_var_is_propagated.as_ref().unwrap()[i]));                        
+                        cell.little_numbers.push((
+                            value,
+                            false,
+                            self.state.highlight_decided_vars
+                                && !self.state.trail_var_is_propagated.as_ref().unwrap()[i],
+                        ));
                     }
                 }
 
@@ -444,7 +453,7 @@ impl SATApp {
                 }
             }
 
-            for (i,variable) in variables.into_iter().enumerate() {
+            for (i, variable) in variables.into_iter().enumerate() {
                 if let CnfVariable::Bit { row, col, .. } = variable {
                     let cell = &mut self.sudoku[row as usize - 1][col as usize - 1];
                     cell.draw_big_number = false;
@@ -452,7 +461,9 @@ impl SATApp {
                     // Only keep the numbers compatible with this variable (that is part of the trail)
                     cell.little_numbers
                         .retain(|x| variable.get_possible_numbers().contains(&x.0));
-                    if self.state.highlight_decided_vars && !self.state.trail_var_is_propagated.as_ref().unwrap()[i] {
+                    if self.state.highlight_decided_vars
+                        && !self.state.trail_var_is_propagated.as_ref().unwrap()[i]
+                    {
                         for x in &mut cell.little_numbers {
                             x.2 = true;
                         }

--- a/src/gui/sudoku_grid.rs
+++ b/src/gui/sudoku_grid.rs
@@ -301,7 +301,7 @@ impl SATApp {
                         let mut visible: Vec<(i32, bool, bool)> = cell.little_numbers.clone();
 
                         // Keep the positive values and underlined negative values (from conflict literals)
-                        visible.retain(|&x| x.0 > 0 || x.1 || x.2);
+                        visible.retain(|&x| x.0 > 0 || x.1 || (x.2 && !cell.clue));
 
                         if !visible.is_empty() {
                             cell.little_numbers = visible;

--- a/src/gui/sudoku_grid.rs
+++ b/src/gui/sudoku_grid.rs
@@ -291,7 +291,7 @@ impl SATApp {
                         let cell = &mut self.sudoku[row as usize - 1][col as usize - 1];
 
                         cell.draw_big_number = false;
-                        cell.little_numbers.push((value, false, !self.state.trail_var_is_propagated.as_ref().unwrap()[i]));                        
+                        cell.little_numbers.push((value, false, self.state.highlight_decided_vars && !self.state.trail_var_is_propagated.as_ref().unwrap()[i]));                        
                     }
                 }
 
@@ -452,7 +452,7 @@ impl SATApp {
                     // Only keep the numbers compatible with this variable (that is part of the trail)
                     cell.little_numbers
                         .retain(|x| variable.get_possible_numbers().contains(&x.0));
-                    if !self.state.trail_var_is_propagated.as_ref().unwrap()[i] {
+                    if self.state.highlight_decided_vars && !self.state.trail_var_is_propagated.as_ref().unwrap()[i] {
                         for x in &mut cell.little_numbers {
                             x.2 = true;
                         }

--- a/src/gui/sudoku_grid.rs
+++ b/src/gui/sudoku_grid.rs
@@ -197,7 +197,7 @@ impl SATApp {
                     let values = variable
                         .get_possible_numbers()
                         .into_iter()
-                        .map(|x| (x, { x == cell.value.unwrap_or(0) }));
+                        .map(|x| (x, { x == cell.value.unwrap_or(0) }, false));
 
                     cell.draw_big_number = false;
 
@@ -210,7 +210,7 @@ impl SATApp {
                     cell.little_numbers.push((value, {
                         value == cell.value.unwrap_or(0)
                             || (value < 0 && value != -cell.value.unwrap_or(0))
-                    }));
+                    }, false));
 
                     cell.draw_big_number = false;
                 }
@@ -277,7 +277,7 @@ impl SATApp {
                         cell.draw_big_number = false;
 
                         // Add the negations of conflict literals as underlined little numbers (so the user knows what the conflict was)
-                        cell.little_numbers.push((-1 * *value, true));
+                        cell.little_numbers.push((-1 * *value, true, false));
                     }
                 }
             }
@@ -286,24 +286,22 @@ impl SATApp {
             if let Some(_conflict_index) = self.state.clicked_constraint_index {
                 let variables = self.state.trail.clone().unwrap();
 
-                for variable in variables {
+                for (i,variable) in variables.into_iter().enumerate() {
                     if let CnfVariable::Decimal { row, col, value } = variable {
                         let cell = &mut self.sudoku[row as usize - 1][col as usize - 1];
 
-                        if !cell.little_numbers.contains(&(value, true)) {
-                            cell.draw_big_number = false;
-                            cell.little_numbers.push((value, false));
-                        }
+                        cell.draw_big_number = false;
+                        cell.little_numbers.push((value, false, !self.state.trail_var_is_propagated.as_ref().unwrap()[i]));                        
                     }
                 }
 
                 // Remove red little literals/numbers (negatives) from cell, if there is at least one blue literal/number (positive) in it
                 for row in self.sudoku.iter_mut() {
                     for cell in row.iter_mut() {
-                        let mut visible: Vec<(i32, bool)> = cell.little_numbers.clone();
+                        let mut visible: Vec<(i32, bool, bool)> = cell.little_numbers.clone();
 
                         // Keep the positive values and underlined negative values (from conflict literals)
-                        visible.retain(|&x| x.0 > 0 || x.1);
+                        visible.retain(|&x| x.0 > 0 || x.1 || x.2);
 
                         if !visible.is_empty() {
                             cell.little_numbers = visible;
@@ -334,15 +332,15 @@ impl SATApp {
         for row in self.sudoku.iter_mut() {
             for cell in row.iter_mut() {
                 cell.little_numbers = vec![
-                    (1, true),
-                    (2, true),
-                    (3, true),
-                    (4, true),
-                    (5, true),
-                    (6, true),
-                    (7, true),
-                    (8, true),
-                    (9, true),
+                    (1, true, false),
+                    (2, true, false),
+                    (3, true, false),
+                    (4, true, false),
+                    (5, true, false),
+                    (6, true, false),
+                    (7, true, false),
+                    (8, true, false),
+                    (9, true, false),
                 ];
             }
         }
@@ -433,20 +431,20 @@ impl SATApp {
             for row in self.sudoku.iter_mut() {
                 for cell in row.iter_mut() {
                     cell.little_numbers.extend(vec![
-                        (1, false),
-                        (2, false),
-                        (3, false),
-                        (4, false),
-                        (5, false),
-                        (6, false),
-                        (7, false),
-                        (8, false),
-                        (9, false),
+                        (1, false, false),
+                        (2, false, false),
+                        (3, false, false),
+                        (4, false, false),
+                        (5, false, false),
+                        (6, false, false),
+                        (7, false, false),
+                        (8, false, false),
+                        (9, false, false),
                     ]);
                 }
             }
 
-            for variable in variables {
+            for (i,variable) in variables.into_iter().enumerate() {
                 if let CnfVariable::Bit { row, col, .. } = variable {
                     let cell = &mut self.sudoku[row as usize - 1][col as usize - 1];
                     cell.draw_big_number = false;
@@ -454,6 +452,11 @@ impl SATApp {
                     // Only keep the numbers compatible with this variable (that is part of the trail)
                     cell.little_numbers
                         .retain(|x| variable.get_possible_numbers().contains(&x.0));
+                    if !self.state.trail_var_is_propagated.as_ref().unwrap()[i] {
+                        for x in &mut cell.little_numbers {
+                            x.2 = true;
+                        }
+                    }
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,12 @@ impl Trail {
             .collect()
     }
 
-    pub fn push(&mut self, conflict_literals: Vec<i32>, trail: Vec<i32>, var_is_propagated: Vec<bool>) {
+    pub fn push(
+        &mut self,
+        conflict_literals: Vec<i32>,
+        trail: Vec<i32>,
+        var_is_propagated: Vec<bool>,
+    ) {
         self.conflict_literals.borrow_mut().push(conflict_literals);
         self.trail.borrow_mut().push(trail);
         self.var_is_propagated.borrow_mut().push(var_is_propagated);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ impl Default for ConstraintList {
 pub struct Trail {
     pub conflict_literals: Rc<RefCell<Vec<Vec<i32>>>>,
     pub trail: Rc<RefCell<Vec<Vec<i32>>>>,
+    pub var_is_propagated: Rc<RefCell<Vec<Vec<bool>>>>,
 }
 
 impl Trail {
@@ -81,6 +82,7 @@ impl Trail {
         Self {
             conflict_literals: Rc::new(RefCell::new(Vec::new())),
             trail: Rc::new(RefCell::new(Vec::new())),
+            var_is_propagated: Rc::new(RefCell::new(Vec::new())),
         }
     }
 
@@ -97,14 +99,16 @@ impl Trail {
             .collect()
     }
 
-    pub fn push(&mut self, conflict_literals: Vec<i32>, trail: Vec<i32>) {
+    pub fn push(&mut self, conflict_literals: Vec<i32>, trail: Vec<i32>, var_is_propagated: Vec<bool>) {
         self.conflict_literals.borrow_mut().push(conflict_literals);
         self.trail.borrow_mut().push(trail);
+        self.var_is_propagated.borrow_mut().push(var_is_propagated);
     }
 
     pub fn clear(&mut self) {
         self.conflict_literals.borrow_mut().clear();
         self.trail.borrow_mut().clear();
+        self.var_is_propagated.borrow_mut().clear();
     }
 
     pub fn trail_at_index(&self, index: usize) -> Vec<i32> {
@@ -113,6 +117,10 @@ impl Trail {
 
     pub fn literals_at_index(&self, index: usize) -> Vec<i32> {
         self.conflict_literals.borrow()[index].clone()
+    }
+
+    pub fn var_is_propagated_at_index(&self, index: usize) -> Vec<bool> {
+        self.var_is_propagated.borrow()[index].clone()
     }
 
     pub fn len(&self) -> usize {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -56,8 +56,16 @@ fn test_trail() {
     let var_propagated_data = vec![vec![false, true, false], vec![true, true, false]];
     let mut trail = Trail::new();
 
-    trail.push(conflict_literals[0].clone(), trail_data[0].clone(), var_propagated_data[0].clone());
-    trail.push(conflict_literals[1].clone(), trail_data[1].clone(), var_propagated_data[1].clone());
+    trail.push(
+        conflict_literals[0].clone(),
+        trail_data[0].clone(),
+        var_propagated_data[0].clone(),
+    );
+    trail.push(
+        conflict_literals[1].clone(),
+        trail_data[1].clone(),
+        var_propagated_data[1].clone(),
+    );
     assert_eq!(trail.len(), 2);
     assert_eq!(trail.trail_at_index(1), vec![4, 5, 6]);
     assert_eq!(trail.literals_at_index(1), vec![300, 301]);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -53,16 +53,20 @@ fn test_constraint_list() {
 fn test_trail() {
     let conflict_literals = vec![vec![100, 101], vec![300, 301]];
     let trail_data = vec![vec![1, 2, 3], vec![4, 5, 6]];
+    let var_propagated_data = vec![vec![false, true, false], vec![true, true, false]];
     let mut trail = Trail::new();
 
-    trail.push(conflict_literals[0].clone(), trail_data[0].clone());
-    trail.push(conflict_literals[1].clone(), trail_data[1].clone());
+    trail.push(conflict_literals[0].clone(), trail_data[0].clone(), var_propagated_data[0].clone());
+    trail.push(conflict_literals[1].clone(), trail_data[1].clone(), var_propagated_data[1].clone());
     assert_eq!(trail.len(), 2);
     assert_eq!(trail.trail_at_index(1), vec![4, 5, 6]);
+    assert_eq!(trail.literals_at_index(1), vec![300, 301]);
+    assert_eq!(trail.var_is_propagated_at_index(1), vec![true, true, false]);
     assert_eq!(trail.is_empty(), false);
 
     trail.clear();
     assert_eq!(trail.len(), 0);
     assert_eq!(trail.is_empty(), true);
     assert_eq!(trail.conflict_literals.borrow().len(), 0);
+    assert_eq!(trail.var_is_propagated.borrow().len(), 0);
 }


### PR DESCRIPTION
Allow the user to highlight decided variables in the trail, meaning variables that have not been propagated from an other variable. Also, some modifications to the GUI's colors were made with accessibility in mind (maintaining high contrast).